### PR TITLE
EditorHeader: Adds min height so that it keeps correct height even when there is no InlineSelect inside

### DIFF
--- a/src/query-builder/EditorHeader.tsx
+++ b/src/query-builder/EditorHeader.tsx
@@ -22,5 +22,6 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({ children }) => {
 const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
   root: css({
     padding: theme.spacing(0, 1),
+    minHeight: theme.spacing(4),
   }),
 }));

--- a/src/query-builder/EditorHeader.tsx
+++ b/src/query-builder/EditorHeader.tsx
@@ -21,7 +21,6 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({ children }) => {
 
 const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
   root: css({
-    padding: theme.spacing(0, 1),
     minHeight: theme.spacing(4),
   }),
 }));

--- a/src/query-builder/EditorHeader.tsx
+++ b/src/query-builder/EditorHeader.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/css";
 import { GrafanaTheme2 } from "@grafana/data";
 import { stylesFactory, useTheme2 } from "@grafana/ui";
 import React from "react";
-import { Stack } from "./Stack";
 
 interface EditorHeaderProps {}
 
@@ -10,17 +9,15 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({ children }) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
-  return (
-    <div className={styles.root}>
-      <Stack gap={3} alignItems="center">
-        {children}
-      </Stack>
-    </div>
-  );
+  return <div className={styles.root}>{children}</div>;
 };
 
 const getStyles = stylesFactory((theme: GrafanaTheme2) => ({
   root: css({
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: theme.spacing(3),
     minHeight: theme.spacing(4),
   }),
 }));


### PR DESCRIPTION
The EditorHeader changes height when there is no InlineSelect inside it, this makes the height consistent. Had to remove the Stack, it created unnecessary nesting anyway 

Removed the padding so that it's aligned with the things below the right side padding made the editor toggle unalined 
Before without InlineSelect
![Screenshot from 2021-12-07 14-38-26](https://user-images.githubusercontent.com/10999/145203124-a156709d-da71-4d49-a284-565110dd09ea.png)
Before with InlineSelect
![Screenshot from 2021-12-07 14-38-52](https://user-images.githubusercontent.com/10999/145203166-7841cc4a-a906-4fde-b3bd-236f510b881d.png)

After without inline select 
![Screenshot from 2021-12-08 12-42-46](https://user-images.githubusercontent.com/10999/145202851-fcfae985-6863-4763-bfa0-55db3943f3c4.png)

