### PR TITLE
CI: Build library in CI before publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'
         run: yarn
+        
+      - name: Build library
+        if: steps.version_check.outputs.changed == 'true'
+        run: yarn build
 
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'


### PR DESCRIPTION
noticed that published packages have no dist folder 