### PR TITLE
Change EditorField width type to string | number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.15",
+  "version": "0.0.2-canary.16",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export * from './query-builder'
-export * from './sql-editor' 
+export * from "./query-builder";
+export * from "./sql-editor";
+export * from "./types";

--- a/src/query-builder/EditorField.tsx
+++ b/src/query-builder/EditorField.tsx
@@ -8,7 +8,7 @@ import { Space } from './Space';
 interface EditorFieldProps {
   label: string;
   children: React.ReactElement;
-  width?: number;
+  width?: number | string;
   optional?: boolean;
   tooltip?: PopoverContent;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export enum EditorMode {
+  Builder = "builder",
+  Code = "code",
+}


### PR DESCRIPTION
I need to pass `'100%'` to min width in order to make things align well.

Add EditorMode enum as well.