### PR TITLE
SQLEditor: Ignore case when handling keywords and operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.18",
+  "version": "0.0.2-canary.19",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/sql-editor/standardSql/getStandardSuggestions.test.ts
+++ b/src/sql-editor/standardSql/getStandardSuggestions.test.ts
@@ -148,7 +148,7 @@ describe('getStandardSuggestions', () => {
       suggestionsRegistry
     );
 
-    expect(result).toHaveLength(1);
+    expect(result).toHaveLength(5);
     expect(result[0].label).toEqual(customComparisonOperator.operator);
   });
 
@@ -175,7 +175,7 @@ describe('getStandardSuggestions', () => {
       suggestionsRegistry
     );
 
-    expect(result).toHaveLength(0);
+    expect(result).toHaveLength(4);
   });
 
   it('suggests SELECT and SELECT FROM from the standard registry', async () => {
@@ -222,7 +222,7 @@ describe('getStandardSuggestions', () => {
           "insertText": "SELECT $2 FROM $1",
           "insertTextRules": 4,
           "kind": 27,
-          "label": "SELECT <column> FROM <table>>",
+          "label": "SELECT <column> FROM <table>",
           "range": Object {
             "endColumn": 7,
             "endLineNumber": 1,

--- a/src/sql-editor/standardSql/language.ts
+++ b/src/sql-editor/standardSql/language.ts
@@ -1,23 +1,23 @@
 // STD basic SQL
-export const SELECT = 'SELECT';
-export const FROM = 'FROM';
-export const WHERE = 'WHERE';
-export const GROUP = 'GROUP';
-export const ORDER = 'ORDER';
-export const BY = 'BY';
-export const DESC = 'DESC';
-export const ASC = 'ASC';
-export const LIMIT = 'LIMIT';
-export const WITH = 'WITH';
-export const AS = 'AS';
-export const SCHEMA = 'SCHEMA';
+export const SELECT = 'select';
+export const FROM = 'from';
+export const WHERE = 'where';
+export const GROUP = 'group';
+export const ORDER = 'order';
+export const BY = 'by';
+export const DESC = 'desc';
+export const ASC = 'asc';
+export const LIMIT = 'limit';
+export const WITH = 'with';
+export const AS = 'as';
+export const SCHEMA = 'schema';
 
-export const KEYWORDS = [SELECT, FROM, WHERE, GROUP, ORDER, BY, DESC, ASC, LIMIT, WITH, SCHEMA];
+
 
 export const STD_STATS = ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'];
 
-export const AND = 'AND';
-export const OR = 'OR';
+export const AND = 'and';
+export const OR = 'or';
 export const LOGICAL_OPERATORS = [AND, OR];
 
 export const EQUALS = '=';

--- a/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
+++ b/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
@@ -8,20 +8,11 @@ import {
   SuggestionKind,
 } from '../types';
 import {
-  AS,
   ASC,
-  BY,
   DESC,
-  FROM,
-  GROUP,
-  LIMIT,
   LOGICAL_OPERATORS,
-  ORDER,
-  SELECT,
   STD_OPERATORS,
   STD_STATS,
-  WHERE,
-  WITH,
 } from './language';
 import { FunctionsRegistryItem, OperatorsRegistryItem, SuggestionsRegistyItem } from './types';
 
@@ -40,16 +31,16 @@ export const initStandardSuggestions =
         suggestions: (_, m) =>
           Promise.resolve([
             {
-              label: `${SELECT} <column>`,
-              insertText: `${SELECT} $0`,
+              label: `SELECT <column>`,
+              insertText: `SELECT $0`,
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Snippet,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.Medium,
             },
             {
-              label: `${SELECT} <column> ${FROM} <table>>`,
-              insertText: `${SELECT} $2 ${FROM} $1`,
+              label: `SELECT <column> FROM <table>`,
+              insertText: `SELECT $2 FROM $1`,
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Snippet,
               command: TRIGGER_SUGGEST,
@@ -63,8 +54,8 @@ export const initStandardSuggestions =
         suggestions: (_, m) =>
           Promise.resolve([
             {
-              label: `${WITH} <alias> ${AS} ( ... )`,
-              insertText: `${WITH} $1  ${AS} ( $2 )`,
+              label: `WITH <alias> AS ( ... )`,
+              insertText: `WITH $1  AS ( $2 )`,
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Snippet,
               command: TRIGGER_SUGGEST,
@@ -110,8 +101,9 @@ export const initStandardSuggestions =
         suggestions: (_, m) =>
           Promise.resolve([
             {
-              label: FROM,
-              insertText: `${FROM} $0`,
+              label: 'FROM', 
+              insertText: `FROM $0`,
+              command: TRIGGER_SUGGEST,
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Keyword,
             },
@@ -151,8 +143,8 @@ export const initStandardSuggestions =
         suggestions: (_, m) =>
           Promise.resolve([
             {
-              label: WHERE,
-              insertText: `${WHERE} `,
+              label: 'WHERE',
+              insertText: `WHERE `,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.MediumHigh,
               kind: CompletionItemKind.Keyword,
@@ -215,7 +207,7 @@ export const initStandardSuggestions =
           Promise.resolve([
             {
               label: 'GROUP BY',
-              insertText: `${GROUP} ${BY} `,
+              insertText: `GROUP BY `,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.MediumHigh,
               kind: CompletionItemKind.Keyword,
@@ -229,14 +221,14 @@ export const initStandardSuggestions =
           Promise.resolve([
             {
               label: 'ORDER BY',
-              insertText: `${ORDER} ${BY} `,
+              insertText: `ORDER BY `,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.Medium,
               kind: CompletionItemKind.Keyword,
             },
             {
               label: 'ORDER BY(ascending)',
-              insertText: `${ORDER} ${BY} $1 ASC `,
+              insertText: `ORDER BY $1 ASC `,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.MediumLow,
               kind: CompletionItemKind.Snippet,
@@ -244,7 +236,7 @@ export const initStandardSuggestions =
             },
             {
               label: 'ORDER BY(descending)',
-              insertText: `${ORDER} ${BY} $1 DESC`,
+              insertText: `ORDER BY $1 DESC`,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.MediumLow,
               kind: CompletionItemKind.Snippet,
@@ -260,7 +252,7 @@ export const initStandardSuggestions =
           Promise.resolve([
             {
               label: 'LIMIT',
-              insertText: `${LIMIT} `,
+              insertText: `LIMIT `,
               command: TRIGGER_SUGGEST,
               sortText: CompletionItemPriority.MediumLow,
               kind: CompletionItemKind.Keyword,

--- a/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
+++ b/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
@@ -1,5 +1,5 @@
 import { StatementPosition, TokenType } from '../types';
-import { AND, ASC, BY, DESC, EQUALS, FROM, GROUP, NOT_EQUALS, ORDER, SELECT, WHERE, WITH } from './language';
+import { AND, AS, ASC, BY, DESC, EQUALS, FROM, GROUP, NOT_EQUALS, ORDER, SELECT, WHERE, WITH } from './language';
 import { StatementPositionResolversRegistryItem } from './types';
 
 export function initStatementPositionResolvers(): StatementPositionResolversRegistryItem[] {
@@ -15,7 +15,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
             (currentToken.is(TokenType.Keyword, SELECT) && currentToken.previous === null) ||
             previousIsSlash ||
             (currentToken.isIdentifier() && (previousIsSlash || currentToken?.previous === null)) ||
-            (currentToken.isIdentifier() && SELECT.startsWith(currentToken.value))
+            (currentToken.isIdentifier() && SELECT.startsWith(currentToken.value.toLowerCase())) 
         ),
     },
     {
@@ -33,13 +33,13 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       id: StatementPosition.AfterSelectKeyword,
       name: StatementPosition.AfterSelectKeyword,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
-        Boolean(previousNonWhiteSpace?.value === SELECT),
+        Boolean(previousNonWhiteSpace?.value.toLowerCase() === SELECT),
     },
     {
       id: StatementPosition.AfterSelectArguments,
       name: StatementPosition.AfterSelectArguments,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
-        return Boolean(previousKeyword?.value === SELECT && previousNonWhiteSpace?.value === ',');
+        return Boolean(previousKeyword?.value.toLowerCase() === SELECT && previousNonWhiteSpace?.value === ',');
       },
     },
     {
@@ -47,7 +47,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       name: StatementPosition.AfterSelectFuncFirstArgument,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
         return Boolean(
-          (previousKeyword?.value.toLowerCase() === 'select' || previousKeyword?.value.toLowerCase() === 'as')  &&
+          (previousKeyword?.value.toLowerCase() === SELECT || previousKeyword?.value.toLowerCase() === AS)  &&
             (previousNonWhiteSpace?.is(TokenType.Parenthesis, '(') || currentToken?.is(TokenType.Parenthesis, '()'))
         );
       },
@@ -56,7 +56,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       id: StatementPosition.SelectAlias,
       name: StatementPosition.SelectAlias,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
-        if (previousNonWhiteSpace?.value === ',' && previousKeyword?.value.toLowerCase() === 'as') {
+        if (previousNonWhiteSpace?.value === ',' && previousKeyword?.value.toLowerCase() === AS) {
           return true
         }
   
@@ -70,9 +70,8 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
         // cloudwatch specific commented out
         // Boolean(previousKeyword?.value === SELECT && previousNonWhiteSpace?.isParenthesis()),
-
         return Boolean(
-          (previousKeyword?.value === SELECT && previousNonWhiteSpace?.value !== ',') ||
+          (previousKeyword?.value.toLowerCase() === SELECT && previousNonWhiteSpace?.value !== ',') ||
             ((currentToken?.isKeyword() || currentToken?.isIdentifier()) &&
               FROM.toLowerCase().startsWith(currentToken.value.toLowerCase()))
         );
@@ -82,16 +81,16 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       id: StatementPosition.AfterFromKeyword,
       name: StatementPosition.AfterFromKeyword,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
-        Boolean(previousNonWhiteSpace?.value === FROM),
+        Boolean(previousNonWhiteSpace?.value.toLowerCase() === FROM),
     },
     {
       id: StatementPosition.AfterFrom,
       name: StatementPosition.AfterFrom,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
         Boolean(
-          (previousKeyword?.value === FROM && previousNonWhiteSpace?.isDoubleQuotedString()) ||
-            (previousKeyword?.value === FROM && previousNonWhiteSpace?.isIdentifier()) ||
-            (previousKeyword?.value === FROM && previousNonWhiteSpace?.isVariable())
+          (previousKeyword?.value.toLowerCase() === FROM && previousNonWhiteSpace?.isDoubleQuotedString()) ||
+            (previousKeyword?.value.toLowerCase() === FROM && previousNonWhiteSpace?.isIdentifier()) ||
+            (previousKeyword?.value.toLowerCase() === FROM && previousNonWhiteSpace?.isVariable())
             //  cloudwatch specific
             // (previousKeyword?.value === SCHEMA && previousNonWhiteSpace?.is(TokenType.Parenthesis, ')'))
         ),
@@ -101,7 +100,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       name: StatementPosition.AfterTable,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
         return Boolean(
-          previousKeyword?.value === FROM &&
+          previousKeyword?.value.toLowerCase() === FROM &&
             (previousNonWhiteSpace?.isVariable() || previousNonWhiteSpace?.value !== '')
         );
       },
@@ -111,7 +110,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       name: StatementPosition.WhereKeyword,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
         Boolean(
-          previousKeyword?.value === WHERE &&
+          previousKeyword?.value.toLowerCase() === WHERE &&
             (previousNonWhiteSpace?.isKeyword() ||
               previousNonWhiteSpace?.is(TokenType.Parenthesis, '(') ||
               previousNonWhiteSpace?.is(TokenType.Operator, AND))
@@ -122,7 +121,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       name: StatementPosition.WhereComparisonOperator,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
         Boolean(
-          previousKeyword?.value === WHERE &&
+          previousKeyword?.value.toLowerCase() === WHERE &&
             (previousNonWhiteSpace?.isIdentifier() || previousNonWhiteSpace?.isDoubleQuotedString())
         ),
     },
@@ -131,7 +130,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       name: StatementPosition.WhereValue,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
         Boolean(
-          previousKeyword?.value === WHERE &&
+          previousKeyword?.value.toLowerCase() === WHERE &&
             (previousNonWhiteSpace?.is(TokenType.Operator, EQUALS) ||
               previousNonWhiteSpace?.is(TokenType.Operator, NOT_EQUALS))
         ),
@@ -141,7 +140,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       name: StatementPosition.AfterWhereValue,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
         return Boolean(
-          previousKeyword?.value === WHERE &&
+          previousKeyword?.value.toLowerCase() === WHERE &&
             (previousNonWhiteSpace?.isString() ||
               previousNonWhiteSpace?.isNumber() ||
               (previousNonWhiteSpace?.is(TokenType.IdentifierQuote) &&

--- a/src/sql-editor/utils/LinkedToken.ts
+++ b/src/sql-editor/utils/LinkedToken.ts
@@ -48,7 +48,8 @@ export class LinkedToken {
 
   is(type: TokenType, value?: string | number | boolean): boolean {
     const isType = this.type === type;
-    return value !== undefined ? isType && this.value === value : isType;
+    
+    return value !== undefined ? isType && compareTokenWithValue(type, this, value)  : isType;
   }
 
   getPreviousNonWhiteSpaceToken(): LinkedToken | null {
@@ -66,7 +67,8 @@ export class LinkedToken {
     let curr = this.previous;
     while (curr != null) {
       const isType = curr.type === type;
-      if (value !== undefined ? isType && curr.value === value : isType) {
+      
+      if (value !== undefined ? isType && compareTokenWithValue(type, curr, value)  : isType) {
         return curr;
       }
       curr = curr.previous;
@@ -84,7 +86,8 @@ export class LinkedToken {
       }
 
       const isType = curr.type === type;
-      if (value !== undefined ? isType && curr.value === value : isType) {
+      
+      if (value !== undefined ? isType && compareTokenWithValue(type, curr, value) : isType) {
         return tokens;
       }
       if (!curr.isWhiteSpace()) {
@@ -106,7 +109,8 @@ export class LinkedToken {
       }
 
       const isType = curr.type === type;
-      if (value !== undefined ? isType && curr.value === value : isType) {
+
+      if (value !== undefined ? isType && compareTokenWithValue(type, curr, value) : isType) {
         return tokens;
       }
       if (!curr.isWhiteSpace()) {
@@ -144,11 +148,17 @@ export class LinkedToken {
     let curr = this.next;
     while (curr != null) {
       const isType = curr.type === type;
-      if (value !== undefined ? isType && curr.value === value : isType) {
+
+      if (value !== undefined ? isType && compareTokenWithValue(type, curr, value) : isType) {
         return curr;
       }
       curr = curr.next;
     }
     return null;
   }
+}
+
+
+function compareTokenWithValue(type: TokenType, token: LinkedToken, value: string | number | boolean) {
+  return (type === TokenType.Keyword || type === TokenType.Operator) ? token.value.toLowerCase() === value.toString().toLowerCase() : token.value === value;
 }


### PR DESCRIPTION
Makes position resolvers ignore case of keywords and operators.
Bumps version.