### PR TITLE
EditorField: Extend EditorField with Field props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.27",
+  "version": "0.0.2-canary.28",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/query-builder/EditorField.tsx
+++ b/src/query-builder/EditorField.tsx
@@ -1,11 +1,11 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Field, Icon, PopoverContent, stylesFactory, Tooltip, useTheme2, ReactUtils } from '@grafana/ui';
-import React from 'react';
+import React, { ComponentProps } from 'react';
 
 import { Space } from './Space';
 
-interface EditorFieldProps {
+interface EditorFieldProps extends ComponentProps<typeof Field>{
   label: string;
   children: React.ReactElement;
   width?: number | string;
@@ -14,10 +14,10 @@ interface EditorFieldProps {
 }
 
 export const EditorField: React.FC<EditorFieldProps> = (props) => {
-  const { label, optional, tooltip, children } = props;
+  const { label, optional, tooltip, children, width, ...fieldProps } = props;
 
   const theme = useTheme2();
-  const styles = getStyles(theme, props);
+  const styles = getStyles(theme, width);
   const childInputId = ReactUtils.getChildId(children);
 
   const labelEl = (
@@ -37,17 +37,17 @@ export const EditorField: React.FC<EditorFieldProps> = (props) => {
 
   return (
     <div className={styles.root}>
-      <Field className={styles.field} label={labelEl}>
+      <Field className={styles.field} label={labelEl} {...fieldProps}>
         <div className={styles.child}>{children}</div>
       </Field>
     </div>
   );
 };
 
-const getStyles = stylesFactory((theme: GrafanaTheme2, props: EditorFieldProps) => {
+const getStyles = stylesFactory((theme: GrafanaTheme2, width?: number | string) => {
   return {
     root: css({
-      minWidth: theme.spacing(props.width ?? 0),
+      minWidth: theme.spacing(width ?? 0),
     }),
     label: css({
       fontSize: 12,


### PR DESCRIPTION
For Loki query builder, we would like to have option to show query field error for some cases. Field component has error showing functionality. However, `EditorField` currently doesn't extent `Field` props and therefore there is no way how to pass error to it (or any other props).

In this PR, we would like to extend `EditorField` with `Field` props so when using `EditorField`, we can use all other `Field` props.

<img width="240" alt="image" src="https://user-images.githubusercontent.com/30407135/164463961-b87618f5-c20c-4d4a-b495-5f8da826ff16.png">

Related to https://github.com/grafana/grafana/pull/47890