### PR TITLE
EditorField: Use htmlFor as childInputId if provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.31",
+  "version": "0.0.2-canary.32",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/query-builder/EditorField.tsx
+++ b/src/query-builder/EditorField.tsx
@@ -5,7 +5,7 @@ import React, { ComponentProps } from 'react';
 
 import { Space } from './Space';
 
-interface EditorFieldProps extends ComponentProps<typeof Field>{
+interface EditorFieldProps extends ComponentProps<typeof Field> {
   label: string;
   children: React.ReactElement;
   width?: number | string;
@@ -20,7 +20,7 @@ export const EditorField: React.FC<EditorFieldProps> = (props) => {
   const styles = getStyles(theme, width);
 
   // Null check for backward compatibility
-  const childInputId = ReactUtils?.getChildId(children);
+  const childInputId = fieldProps?.htmlFor || ReactUtils?.getChildId(children);
 
   const labelEl = (
     <>


### PR DESCRIPTION
If `htmlFor` is passed as a prop to `EditorField` use that as the `childInputId`

This is for cases where the child input element is not an immediate child of the `EditorField`. In these cases, the EditorField doesn't get the input element's id and clicking on the label does not focus the input element.

```tsx
<EditorField htmlFor="myId" label="My label">
  <>
    <Select inputId="myId" />
  </>
</EditorField>
```