### PR TITLE
don't suggest opers after where with .

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.33",
+  "version": "0.0.2-canary.34",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
+++ b/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
@@ -235,9 +235,10 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
         Boolean(
           previousKeyword?.value.toLowerCase() === WHERE &&
           !previousNonWhiteSpace?.getPreviousNonWhiteSpaceToken().isOperator() &&
-            !currentToken.isParenthesis() &&
-            (previousNonWhiteSpace?.isIdentifier() ||
-              previousNonWhiteSpace?.isDoubleQuotedString())
+            !currentToken.is(TokenType.Delimiter, '.') &&
+              !currentToken.isParenthesis() &&
+              (previousNonWhiteSpace?.isIdentifier() ||
+                previousNonWhiteSpace?.isDoubleQuotedString())
         ),
     },
     {


### PR DESCRIPTION
after where clause, when typing a dot after table: "table.", don't suggest comparison operators