### PR TITLE
SQL autocomplete: Changed suggestions and priority for completion items

### DIFF
--- a/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
+++ b/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
@@ -9,13 +9,7 @@ import {
   OperatorType,
   SuggestionKind,
 } from '../types';
-import {
-  ASC,
-  DESC,
-  LOGICAL_OPERATORS,
-  STD_OPERATORS,
-  STD_STATS,
-} from './language';
+import { ASC, DESC, LOGICAL_OPERATORS, STD_OPERATORS, STD_STATS } from './language';
 import { FunctionsRegistryItem, MacrosRegistryItem, OperatorsRegistryItem, SuggestionsRegistryItem } from './types';
 import { MACROS } from './macros';
 
@@ -76,6 +70,7 @@ export const initStandardSuggestions =
                 insertText: `\\$${variable.name} `,
                 insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
                 command: TRIGGER_SUGGEST,
+                sortText: CompletionItemPriority.Low,
               };
             })
           );
@@ -152,7 +147,7 @@ export const initStandardSuggestions =
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Function,
               command: TRIGGER_SUGGEST,
-              sortText: CompletionItemPriority.MediumHigh,
+              sortText: CompletionItemPriority.MediumLow,
             })),
           ]),
       },
@@ -408,13 +403,12 @@ export const initOperatorsRegistry = (): OperatorsRegistryItem[] => [
     type: OperatorType.Comparison,
   })),
   ...LOGICAL_OPERATORS.map((o) => ({ id: o, name: o.toUpperCase(), operator: o, type: OperatorType.Logical })),
-  
 ];
 
 function createMacroSuggestionItem(m: MacrosRegistryItem) {
   return {
     label: m.name,
-    insertText: `${"\\" + m.text}${argsString(m.args)} `,
+    insertText: `${'\\' + m.text}${argsString(m.args)} `,
     insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
     kind: CompletionItemKind.Snippet,
     documentation: m.description,
@@ -424,10 +418,7 @@ function createMacroSuggestionItem(m: MacrosRegistryItem) {
 
 function argsString(args?: string[]): string {
   if (!args) {
-    return "()";
+    return '()';
   }
-  return "("
-    .concat(args.map((t, i) => `\${${i}:${t}}`).join(", "))
-    .concat(")");
+  return '('.concat(args.map((t, i) => `\${${i}:${t}}`).join(', ')).concat(')');
 }
-

--- a/src/sql-editor/standardSql/suggestionsKindRegistry.ts
+++ b/src/sql-editor/standardSql/suggestionsKindRegistry.ts
@@ -22,11 +22,7 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
     {
       id: StatementPosition.AfterSelectKeyword,
       name: StatementPosition.AfterSelectKeyword,
-      kind: [
-        SuggestionKind.FunctionsWithArguments,
-        SuggestionKind.Columns,
-        SuggestionKind.SelectMacro,
-      ],
+      kind: [SuggestionKind.FunctionsWithArguments, SuggestionKind.Columns, SuggestionKind.SelectMacro],
     },
     {
       id: StatementPosition.AfterSelectFuncFirstArgument,
@@ -96,7 +92,7 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
     {
       id: StatementPosition.WhereValue,
       name: StatementPosition.WhereValue,
-      kind: [SuggestionKind.Columns, SuggestionKind.FilterMacro, SuggestionKind.TemplateVariables],
+      kind: [SuggestionKind.FilterMacro, SuggestionKind.TemplateVariables],
     },
     {
       id: StatementPosition.AfterWhereValue,
@@ -113,7 +109,7 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
     {
       id: StatementPosition.AfterGroupByKeywords,
       name: StatementPosition.AfterGroupByKeywords,
-      kind: [SuggestionKind.GroupMacro],
+      kind: [SuggestionKind.GroupMacro, SuggestionKind.Columns],
     },
     {
       id: StatementPosition.AfterGroupBy,
@@ -128,10 +124,7 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
     {
       id: StatementPosition.AfterOrderByFunction,
       name: StatementPosition.AfterOrderByFunction,
-      kind: [
-        SuggestionKind.SortOrderDirectionKeyword,
-        SuggestionKind.LimitKeyword,
-      ],
+      kind: [SuggestionKind.SortOrderDirectionKeyword, SuggestionKind.LimitKeyword],
     },
     {
       id: StatementPosition.AfterOrderByDirection,
@@ -141,11 +134,7 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
     {
       id: StatementPosition.AfterIsOperator,
       name: StatementPosition.AfterOrderByDirection,
-      kind: [
-        SuggestionKind.NotKeyword,
-        SuggestionKind.NullValue,
-        SuggestionKind.BoolValues,
-      ],
+      kind: [SuggestionKind.NotKeyword, SuggestionKind.NullValue, SuggestionKind.BoolValues],
     },
     {
       id: StatementPosition.AfterIsNotOperator,

--- a/src/sql-editor/types.ts
+++ b/src/sql-editor/types.ts
@@ -203,7 +203,7 @@ export enum SuggestionKind {
   BoolValues = 'boolValues',
   NullValue = 'nullValue',
   NotKeyword = 'notKeyword',
-  TemplateVariables = "templateVariables",
+  TemplateVariables = 'templateVariables',
 }
 
 // TODO: export from grafana/ui


### PR DESCRIPTION
Have made a few very minor changes to the completion engine:
* Lower priority for `functions` as there might be hundreds of them for some languages
* Lower priority for template variables
* Suggest columns after `group by` keyword
* Remove columns suggestions when "where value" should be specified   