### PR TITLE
SQL Autocomplete: Add standard completion item provider 

### DIFF
--- a/src/sql-editor/components/SQLEditor.tsx
+++ b/src/sql-editor/components/SQLEditor.tsx
@@ -196,7 +196,6 @@ export const registerLanguageAndSuggestions = async (monaco: Monaco, l: Language
       token
     ) => {
       const currentToken = linkedTokenBuilder(monaco, model, position, 'sql');
-
       const statementPosition = getStatementPosition(currentToken, languageSuggestionsRegistries.positionResolvers);
       const kind = getSuggestionKinds(statementPosition, languageSuggestionsRegistries.suggestionKinds);
 

--- a/src/sql-editor/components/SQLEditor.tsx
+++ b/src/sql-editor/components/SQLEditor.tsx
@@ -27,12 +27,7 @@ import {
   StatementPositionResolversRegistryItem,
   SuggestionsRegistryItem,
 } from '../standardSql/types';
-import {
-  initFunctionsRegistry,
-  initMacrosRegistry,
-  initOperatorsRegistry,
-  initStandardSuggestions,
-} from '../standardSql/standardSuggestionsRegistry';
+import { initStandardSuggestions } from '../standardSql/standardSuggestionsRegistry';
 import { initStatementPositionResolvers } from '../standardSql/statementPositionResolversRegistry';
 import { sqlEditorLog } from '../utils/debugger';
 import standardSQLLanguageDefinition from 'sql-editor/standardSql/definition';
@@ -383,11 +378,11 @@ function extendStandardRegistries(id: string, lid: string, customProvider: SQLCo
 function initializeLanguageRegistries(id: string) {
   if (!LANGUAGES_CACHE.has(id)) {
     LANGUAGES_CACHE.set(id, {
-      functions: new Registry(initFunctionsRegistry),
-      operators: new Registry(initOperatorsRegistry),
+      functions: new Registry(),
+      operators: new Registry(),
       suggestionKinds: new Registry(initSuggestionsKindRegistry),
       positionResolvers: new Registry(initStatementPositionResolvers),
-      macros: new Registry(initMacrosRegistry),
+      macros: new Registry(),
     });
   }
 

--- a/src/sql-editor/index.ts
+++ b/src/sql-editor/index.ts
@@ -2,6 +2,7 @@ export { SQLEditor, LanguageDefinition } from './components/SQLEditor';
 export { SQLEditorTestUtils, TestQueryModel } from './test-utils';
 export { LinkedToken } from './utils/LinkedToken';
 export { language as grafanaStandardSQLLanguage, conf as grafanaStandardSQLLanguageConf } from './standardSql/language';
+export { getStandardSQLCompletionProvider } from './standardSql/standardSQLCompletionItemProvider';
 export { SQLMonarchLanguage } from './standardSql/types';
 
 export {

--- a/src/sql-editor/standardSql/definition.ts
+++ b/src/sql-editor/standardSql/definition.ts
@@ -1,16 +1,5 @@
-import { monacoTypes } from '@grafana/ui';
-import { SQLMonarchLanguage } from './types';
-
-export type LanguageDefinition = {
-  id: string;
-  extensions: string[];
-  aliases: string[];
-  mimetypes: string[];
-  loader: (monaco: any) => Promise<{
-    language: SQLMonarchLanguage;
-    conf: monacoTypes.languages.LanguageConfiguration;
-  }>;
-};
+import { LanguageDefinition } from 'sql-editor/components/SQLEditor';
+import { getStandardSQLCompletionProvider } from './standardSQLCompletionItemProvider';
 
 const standardSQLLanguageDefinition: LanguageDefinition = {
   id: 'standardSql',
@@ -18,6 +7,7 @@ const standardSQLLanguageDefinition: LanguageDefinition = {
   aliases: ['sql'],
   mimetypes: [],
   loader: () => import('./language'),
+  completionProvider: getStandardSQLCompletionProvider,
 };
 
 export default standardSQLLanguageDefinition;

--- a/src/sql-editor/standardSql/getStandardSuggestions.test.ts
+++ b/src/sql-editor/standardSql/getStandardSuggestions.test.ts
@@ -189,7 +189,7 @@ describe('getStandardSuggestions', () => {
       id: '$__time',
       text: '$__time',
       type: MacroType.Value,
-      args: []
+      args: [],
     };
 
     const suggestionsRegistry = new Registry(

--- a/src/sql-editor/standardSql/getStandardSuggestions.test.ts
+++ b/src/sql-editor/standardSql/getStandardSuggestions.test.ts
@@ -189,6 +189,7 @@ describe('getStandardSuggestions', () => {
       id: '$__time',
       text: '$__time',
       type: MacroType.Value,
+      args: []
     };
 
     const suggestionsRegistry = new Registry(

--- a/src/sql-editor/standardSql/language.ts
+++ b/src/sql-editor/standardSql/language.ts
@@ -15,8 +15,6 @@ export const WITH = 'with';
 export const AS = 'as';
 export const SCHEMA = 'schema';
 
-export const STD_STATS = ['AVG', 'COUNT', 'MAX', 'MIN', 'SUM'];
-
 export const AND = 'AND';
 export const OR = 'OR';
 export const LOGICAL_OPERATORS = [AND, OR];

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.test.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.test.ts
@@ -5,6 +5,7 @@ import { SQLMonarchLanguage } from './types';
 describe('standardSQLCompletionItemProvider', () => {
   describe('should include completion items based on the provided custom language', () => {
     const language: SQLMonarchLanguage = {
+      id: 'custom-grafana-sql-language',
       tokenizer: {},
       builtinFunctions: ['SUM', 'AVG'],
       logicalOperators: ['AND', 'OR'],
@@ -14,7 +15,7 @@ describe('standardSQLCompletionItemProvider', () => {
     it('should use functions from language', () => {
       expect(completionProvider.supportedFunctions().map((f) => f.name)).toEqual(language.builtinFunctions);
     });
-    it('should combine ', () => {
+    it('should combine operators', () => {
       expect(completionProvider.supportedOperators().map((o) => o.operator)).toEqual(
         language.comparisonOperators.concat(language.logicalOperators)
       );
@@ -23,6 +24,7 @@ describe('standardSQLCompletionItemProvider', () => {
 
   describe('should include completion items based on the provided monaco registry language', () => {
     const language: SQLMonarchLanguage = {
+      id: 'postgres',
       tokenizer: {},
       builtinFunctions: ['SUM', 'AVG'],
       operators: ['AND', 'OR'],
@@ -31,7 +33,7 @@ describe('standardSQLCompletionItemProvider', () => {
     it('should use functions from language', () => {
       expect(completionProvider.supportedFunctions().map((f) => f.name)).toEqual(language.builtinFunctions);
     });
-    it('should combine ', () => {
+    it('should combine operators', () => {
       expect(completionProvider.supportedOperators().map((o) => o.operator)).toEqual(language.operators);
     });
   });

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.test.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.test.ts
@@ -1,0 +1,23 @@
+import { Monaco } from '@grafana/ui';
+import { getStandardSQLCompletionProvider } from './standardSQLCompletionItemProvider';
+import { SQLMonarchLanguage } from './types';
+
+describe('standardSQLCompletionItemProvider', () => {
+  describe('should include completion items based on the provided language', () => {
+    const language: SQLMonarchLanguage = {
+      tokenizer: {},
+      builtinFunctions: ['SUM', 'AVG'],
+      logicalOperators: ['AND', 'OR'],
+      comparisonOperators: ['=', '!='],
+    };
+    const completionProvider = getStandardSQLCompletionProvider({} as Monaco, language);
+    it('should use functions from language', () => {
+      expect(completionProvider.supportedFunctions().map((f) => f.name)).toEqual(language.builtinFunctions);
+    });
+    it('should combine ', () => {
+      expect(completionProvider.supportedOperators().map((o) => o.operator)).toEqual(
+        language.comparisonOperators.concat(language.logicalOperators)
+      );
+    });
+  });
+});

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.test.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.test.ts
@@ -3,7 +3,7 @@ import { getStandardSQLCompletionProvider } from './standardSQLCompletionItemPro
 import { SQLMonarchLanguage } from './types';
 
 describe('standardSQLCompletionItemProvider', () => {
-  describe('should include completion items based on the provided language', () => {
+  describe('should include completion items based on the provided custom language', () => {
     const language: SQLMonarchLanguage = {
       tokenizer: {},
       builtinFunctions: ['SUM', 'AVG'],
@@ -18,6 +18,21 @@ describe('standardSQLCompletionItemProvider', () => {
       expect(completionProvider.supportedOperators().map((o) => o.operator)).toEqual(
         language.comparisonOperators.concat(language.logicalOperators)
       );
+    });
+  });
+
+  describe('should include completion items based on the provided monaco registry language', () => {
+    const language: SQLMonarchLanguage = {
+      tokenizer: {},
+      builtinFunctions: ['SUM', 'AVG'],
+      operators: ['AND', 'OR'],
+    };
+    const completionProvider = getStandardSQLCompletionProvider({} as Monaco, language);
+    it('should use functions from language', () => {
+      expect(completionProvider.supportedFunctions().map((f) => f.name)).toEqual(language.builtinFunctions);
+    });
+    it('should combine ', () => {
+      expect(completionProvider.supportedOperators().map((o) => o.operator)).toEqual(language.operators);
     });
   });
 });

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
@@ -12,7 +12,7 @@ export function getStandardSQLCompletionProvider(
     provider.supportedFunctions = () => language.builtinFunctions.map((f) => ({ id: f, name: f }));
   }
 
-  const operators: Array<Operator> = [];
+  const operators: Operator[] = [];
   if (language?.comparisonOperators?.length) {
     operators.push(
       ...language.comparisonOperators.map((f) => ({

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
@@ -13,7 +13,7 @@ export function getStandardSQLCompletionProvider(
   }
 
   const operators: Array<Operator> = [];
-  if (language?.comparisonOperators.length) {
+  if (language?.comparisonOperators?.length) {
     operators.push(
       ...language.comparisonOperators.map((f) => ({
         id: f.toLocaleLowerCase(),
@@ -23,7 +23,9 @@ export function getStandardSQLCompletionProvider(
     );
   }
 
-  if (language?.logicalOperators.length) {
+  // some languages in the monaco language registry doesn't specify logical operators, only operators. if so, suggest them instead
+  language.logicalOperators = language.logicalOperators ?? language.operators;
+  if (language?.logicalOperators?.length) {
     operators.push(
       ...language.logicalOperators.map((f) => ({ id: f.toLocaleLowerCase(), operator: f, type: OperatorType.Logical }))
     );

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
@@ -23,7 +23,7 @@ export function getStandardSQLCompletionProvider(
     );
   }
 
-  // some languages in the monaco language registry doesn't specify logical operators, only operators. if so, suggest them instead
+  // some languages in the monaco language registry don't specify logical operators, only operators. if so, suggest them instead
   language.logicalOperators = language.logicalOperators ?? language.operators;
   if (language?.logicalOperators?.length) {
     operators.push(

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
@@ -1,5 +1,6 @@
 import { Monaco } from '@grafana/ui';
 import { Operator, OperatorType, SQLCompletionItemProvider } from 'sql-editor/types';
+import { MACROS } from './macros';
 import { SQLMonarchLanguage } from './types';
 
 export function getStandardSQLCompletionProvider(
@@ -29,6 +30,8 @@ export function getStandardSQLCompletionProvider(
   }
 
   provider.supportedOperators = () => operators;
+
+  provider.supportedMacros = () => MACROS;
 
   return provider;
 }

--- a/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
+++ b/src/sql-editor/standardSql/standardSQLCompletionItemProvider.ts
@@ -1,0 +1,34 @@
+import { Monaco } from '@grafana/ui';
+import { Operator, OperatorType, SQLCompletionItemProvider } from 'sql-editor/types';
+import { SQLMonarchLanguage } from './types';
+
+export function getStandardSQLCompletionProvider(
+  monaco: Monaco,
+  language: SQLMonarchLanguage
+): SQLCompletionItemProvider {
+  const provider: SQLCompletionItemProvider = { triggerCharacters: ['.', ' ', '$', ',', '(', "'"] };
+  if (language?.builtinFunctions.length) {
+    provider.supportedFunctions = () => language.builtinFunctions.map((f) => ({ id: f, name: f }));
+  }
+
+  const operators: Array<Operator> = [];
+  if (language?.comparisonOperators.length) {
+    operators.push(
+      ...language.comparisonOperators.map((f) => ({
+        id: f.toLocaleLowerCase(),
+        operator: f,
+        type: OperatorType.Comparison,
+      }))
+    );
+  }
+
+  if (language?.logicalOperators.length) {
+    operators.push(
+      ...language.logicalOperators.map((f) => ({ id: f.toLocaleLowerCase(), operator: f, type: OperatorType.Logical }))
+    );
+  }
+
+  provider.supportedOperators = () => operators;
+
+  return provider;
+}

--- a/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
+++ b/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
@@ -9,9 +9,8 @@ import {
   OperatorType,
   SuggestionKind,
 } from '../types';
-import { ASC, DESC, LOGICAL_OPERATORS, STD_OPERATORS, STD_STATS } from './language';
+import { ASC, DESC } from './language';
 import { FunctionsRegistryItem, MacrosRegistryItem, OperatorsRegistryItem, SuggestionsRegistryItem } from './types';
-import { MACROS } from './macros';
 
 /**
  * This registry glues particular SuggestionKind with an async function that provides completion items for it.
@@ -400,25 +399,6 @@ export const initStandardSuggestions =
           ),
       },
     ];
-
-export const initFunctionsRegistry = (): FunctionsRegistryItem[] => [
-  ...STD_STATS.map((s) => ({
-    id: s,
-    name: s,
-  })),
-];
-
-export const initMacrosRegistry = (): MacrosRegistryItem[] => [...MACROS];
-
-export const initOperatorsRegistry = (): OperatorsRegistryItem[] => [
-  ...STD_OPERATORS.map((o) => ({
-    id: o,
-    name: o,
-    operator: o,
-    type: OperatorType.Comparison,
-  })),
-  ...LOGICAL_OPERATORS.map((o) => ({ id: o, name: o.toUpperCase(), operator: o, type: OperatorType.Logical })),
-];
 
 function createMacroSuggestionItem(m: MacrosRegistryItem) {
   return {

--- a/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
+++ b/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
@@ -69,6 +69,7 @@ export const initStandardSuggestions =
                 insertText: `\\$${variable.name} `,
                 insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
                 command: TRIGGER_SUGGEST,
+                sortText: CompletionItemPriority.Low,
               };
             })
           );
@@ -160,6 +161,7 @@ export const initStandardSuggestions =
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Function,
               command: TRIGGER_SUGGEST,
+              sortText: CompletionItemPriority.MediumLow,
             })),
           ]),
       },

--- a/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
+++ b/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
@@ -69,7 +69,6 @@ export const initStandardSuggestions =
                 insertText: `\\$${variable.name} `,
                 insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
                 command: TRIGGER_SUGGEST,
-                sortText: CompletionItemPriority.Low,
               };
             })
           );
@@ -161,7 +160,6 @@ export const initStandardSuggestions =
               insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
               kind: CompletionItemKind.Function,
               command: TRIGGER_SUGGEST,
-              sortText: CompletionItemPriority.MediumLow,
             })),
           ]),
       },

--- a/src/sql-editor/standardSql/types.ts
+++ b/src/sql-editor/standardSql/types.ts
@@ -46,9 +46,12 @@ export type SuggestionsResolver = <T extends PositionContext = PositionContext>(
 export interface SQLMonarchLanguage extends monacoTypes.languages.IMonarchLanguage {
   keywords?: string[];
   builtinFunctions?: string[];
+
+  /* Example: AND, OR, LIKE */
   logicalOperators?: string[];
+  /* Example: >, <>, = */
   comparisonOperators?: string[];
 
-  //used by basic languages in the monaco registry
+  /** Used by basic languages in the monaco registry **/
   operators?: string[];
 }

--- a/src/sql-editor/standardSql/types.ts
+++ b/src/sql-editor/standardSql/types.ts
@@ -48,4 +48,7 @@ export interface SQLMonarchLanguage extends monacoTypes.languages.IMonarchLangua
   builtinFunctions?: string[];
   logicalOperators?: string[];
   comparisonOperators?: string[];
+
+  //used by basic languages in the monaco registry
+  operators?: string[];
 }

--- a/src/sql-editor/standardSql/types.ts
+++ b/src/sql-editor/standardSql/types.ts
@@ -18,7 +18,7 @@ export interface SuggestionsRegistryItem extends RegistryItem {
 export interface MacrosRegistryItem extends RegistryItem {
   type: MacroType;
   text: string;
-  args?: string[];
+  args: string[];
 }
 
 export interface FunctionsRegistryItem extends RegistryItem {}

--- a/src/sql-editor/types.ts
+++ b/src/sql-editor/types.ts
@@ -1,5 +1,5 @@
 import { Monaco, monacoTypes } from '@grafana/ui';
-import { StatementPositionResolver, SuggestionsResolver } from './standardSql/types';
+import { SQLMonarchLanguage, StatementPositionResolver, SuggestionsResolver } from './standardSql/types';
 import { LinkedToken } from './utils/LinkedToken';
 
 /**
@@ -43,6 +43,13 @@ export interface TableDefinition {
   name: string;
   // Text used for automplete. If not provided name is used.
   completion?: string;
+}
+
+export interface Operator {
+  id: string;
+  operator: string;
+  type: OperatorType;
+  description?: string;
 }
 
 export interface SQLCompletionItemProvider
@@ -120,7 +127,7 @@ export interface SQLCompletionItemProvider
   ) => monacoTypes.languages.CompletionList;
 }
 
-export type LanguageCompletionProvider = (m: Monaco) => SQLCompletionItemProvider;
+export type LanguageCompletionProvider = (m: Monaco, l?: SQLMonarchLanguage) => SQLCompletionItemProvider;
 
 export enum OperatorType {
   Comparison,

--- a/src/sql-editor/utils/LinkedToken.ts
+++ b/src/sql-editor/utils/LinkedToken.ts
@@ -1,4 +1,3 @@
-import { getTemplateSrv } from '@grafana/runtime';
 import { monacoTypes } from '@grafana/ui';
 import { TokenType } from '../types';
 
@@ -52,8 +51,7 @@ export class LinkedToken {
   }
 
   isTemplateVariable(): boolean {
-    const variables = getTemplateSrv()?.getVariables();
-    return variables.find((v) => '$' + v.name === this.value) !== undefined;
+    return this.type === TokenType.Variable;
   }
 
   is(type: TokenType, value?: string | number | boolean): boolean {


### PR DESCRIPTION
This is a continuation on what was started in [this](https://github.com/grafana/grafana-experimental/pull/35) PR. 

This PR adds a completion item provider for standard SQL. This means we're getting decent autocompletion even though no custom language nor custom completion item provider was specified.

The standard completion item provider bases the suggestions on the Monaco language that is used. That means consumer doesn't have to specify for example functions and operators twice, but only once in the language since the completion item provider will pick it up automatically.

This demonstrates the experience when no custom language was specified, effectively using the default standard SQL. 
![standard](https://user-images.githubusercontent.com/2388950/180205080-02f932c4-451c-42c7-ae73-b0adc01e0843.gif)

The standard SQL completion item provider is also exported, so it can be used when composing custom completion item providers. For example, the redshift plugin has no specific needs except for providing suggestions for tables and columns. Therefore it can just spread the standard completion item provider object into the custom completion item provider.

```typescript
export const getRedshiftCompletionProvider: (args: CompletionProviderGetterArgs) => LanguageCompletionProvider =
  ({ getColumns, getTables }) =>
  (monaco, language) => {
    return {
      // get standard SQL completion provider which will resolve functions and macros
      ...(language && getStandardSQLCompletionProvider(monaco, language)),
      tables: {
        resolve: async () => getTables.current(),
      },
      columns: {
        resolve: async (t: string) => getColumns.current(t),
      },
    };
  };
```

This PR moves some default suggestions from the [standardSuggestionRegistry](https://github.com/grafana/grafana-experimental/blob/standard-sql-completion-item-provider/src/sql-editor/standardSql/standardSuggestionsRegistry.ts#L94) to the standard completion item provider. This should make it easier to extend/override defaults. However, there are still some hard coded suggestions in the standardSuggestionRegistry that should be moved to the completion item provider in the future. 

Testing the SQLEditor component where the language/completion item provider resolving takes place is really hard. Will take a deeper look at this tomorrow. 