### PR TITLE
SQL Autocomplete: Support schema in table identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.36",
+  "version": "0.0.2-canary.37",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/sql-editor/components/SQLEditor.tsx
+++ b/src/sql-editor/components/SQLEditor.tsx
@@ -335,9 +335,9 @@ function extendStandardRegistries(id: string, lid: string, customProvider: SQLCo
     const s = stbBehaviour!.suggestions;
     stbBehaviour!.suggestions = async (ctx, m) => {
       const o = await s(ctx, m);
-      const tableTokens = getTableToken(ctx.currentToken);
+      const tableToken = getTableToken(ctx.currentToken);
       const tableNameParser = customProvider.tables?.parseName ?? defaultTableNameParser;
-      const tableIdentifier = tableNameParser(tableTokens);
+      const tableIdentifier = tableNameParser(tableToken);
       const oo = (await customProvider.tables!.resolve!(tableIdentifier)).map((x) => ({
         label: x.name,
         insertText: x.completion ?? x.name,

--- a/src/sql-editor/components/SQLEditor.tsx
+++ b/src/sql-editor/components/SQLEditor.tsx
@@ -129,6 +129,13 @@ export const SQLEditor: React.FC<SQLEditorProps> = ({
               onChange(text, true);
             }
           });
+
+          editor.onKeyUp((e) => {
+            // keyCode 84 is . (DOT)
+            if (e.keyCode === 84) {
+              editor.trigger(TRIGGER_SUGGEST.id, TRIGGER_SUGGEST.id, {});
+            }
+          });
           registerLanguageAndSuggestions(m, language, id);
         }}
       />
@@ -195,7 +202,7 @@ export const registerLanguageAndSuggestions = async (monaco: Monaco, l: Language
       context,
       token
     ) => {
-      const currentToken = linkedTokenBuilder(monaco, model, position, 'sql');
+      const currentToken = linkedTokenBuilder(monaco, model, position, lid);
       const statementPosition = getStatementPosition(currentToken, languageSuggestionsRegistries.positionResolvers);
       const kind = getSuggestionKinds(statementPosition, languageSuggestionsRegistries.suggestionKinds);
 

--- a/src/sql-editor/index.ts
+++ b/src/sql-editor/index.ts
@@ -8,6 +8,7 @@ export { SQLMonarchLanguage } from './standardSql/types';
 export {
   TableDefinition,
   ColumnDefinition,
+  TableIdentifier,
   StatementPlacementProvider,
   SuggestionKindProvider,
   LanguageCompletionProvider,

--- a/src/sql-editor/standardSql/getStandardSuggestions.ts
+++ b/src/sql-editor/standardSql/getStandardSuggestions.ts
@@ -14,7 +14,10 @@ export const getStandardSuggestions = async (
   suggestionsRegistry: Registry<SuggestionsRegistryItem>
 ): Promise<monacoTypes.languages.CompletionItem[]> => {
   let suggestions: monacoTypes.languages.CompletionItem[] = [];
-  const invalidRangeToken = currentToken?.isWhiteSpace() || currentToken?.isParenthesis();
+  const invalidRangeToken =
+    currentToken?.isWhiteSpace() ||
+    currentToken?.isParenthesis() ||
+    (currentToken?.isIdentifier() && currentToken.value.endsWith('.'));
   const range =
     invalidRangeToken || !currentToken?.range
       ? monaco.Range.fromPositions(positionContext.position)

--- a/src/sql-editor/standardSql/language.ts
+++ b/src/sql-editor/standardSql/language.ts
@@ -791,6 +791,7 @@ export const language: SQLMonarchLanguage = {
       { include: '@strings' },
       { include: '@complexIdentifiers' },
       { include: '@scopes' },
+      { include: '@schemaTable' },
       [/[;,.]/, 'delimiter'],
       [/[()]/, '@brackets'],
       [
@@ -810,6 +811,10 @@ export const language: SQLMonarchLanguage = {
     ],
     templateVariables: [[/\$[a-zA-Z0-9]+/, 'variable']],
     macros: [[/\$__[a-zA-Z0-9-_]+/, 'type']],
+    schemaTable: [
+      [/(\w+)\./, 'identifier'],
+      [/(\w+\.\w+)/, 'identifier'],
+    ],
     whitespace: [[/\s+/, 'white']],
     comments: [
       [/--+.*/, 'comment'],

--- a/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
+++ b/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
@@ -107,6 +107,22 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
         Boolean(previousNonWhiteSpace?.value.toLowerCase() === FROM),
     },
     {
+      id: StatementPosition.AfterSchema,
+      name: StatementPosition.AfterSchema,
+      resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
+        // depending on weather the schema was the last token in the query or not, current token might be whitespace or dot. if whitespace, just use the previous token
+        if (currentToken?.isWhiteSpace() && currentToken?.next) {
+          currentToken = currentToken?.previous;
+          previousNonWhiteSpace = currentToken?.getPreviousNonWhiteSpaceToken();
+        }
+        return Boolean(
+          currentToken?.isIdentifier() &&
+            currentToken?.value.endsWith('.') &&
+            previousNonWhiteSpace?.value.toLowerCase() === FROM
+        );
+      },
+    },
+    {
       id: StatementPosition.AfterFrom,
       name: StatementPosition.AfterFrom,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>

--- a/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
+++ b/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
@@ -110,7 +110,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       id: StatementPosition.AfterSchema,
       name: StatementPosition.AfterSchema,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) => {
-        // depending on weather the schema was the last token in the query or not, current token might be whitespace or dot. if whitespace, just use the previous token
+        // depending on whether the schema was the last token in the query or not, current token might be whitespace or dot. if whitespace, just use the previous token
         if (currentToken?.isWhiteSpace() && currentToken?.next) {
           currentToken = currentToken?.previous;
           previousNonWhiteSpace = currentToken?.getPreviousNonWhiteSpaceToken();

--- a/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
+++ b/src/sql-editor/standardSql/statementPositionResolversRegistry.ts
@@ -104,7 +104,7 @@ export function initStatementPositionResolvers(): StatementPositionResolversRegi
       id: StatementPosition.AfterFromKeyword,
       name: StatementPosition.AfterFromKeyword,
       resolve: (currentToken, previousKeyword, previousNonWhiteSpace, previousIsSlash) =>
-        Boolean(previousNonWhiteSpace?.value.toLowerCase() === FROM),
+        Boolean(!currentToken?.value.includes('.') && previousNonWhiteSpace?.value.toLowerCase() === FROM),
     },
     {
       id: StatementPosition.AfterSchema,

--- a/src/sql-editor/standardSql/suggestionsKindRegistry.ts
+++ b/src/sql-editor/standardSql/suggestionsKindRegistry.ts
@@ -55,6 +55,11 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
       kind: [SuggestionKind.Tables, SuggestionKind.TableMacro],
     },
     {
+      id: StatementPosition.AfterSchema,
+      name: StatementPosition.AfterSchema,
+      kind: [SuggestionKind.Tables, SuggestionKind.TableMacro],
+    },
+    {
       id: StatementPosition.SelectAlias,
       name: StatementPosition.SelectAlias,
       kind: [SuggestionKind.Columns, SuggestionKind.FunctionsWithArguments],

--- a/src/sql-editor/types.ts
+++ b/src/sql-editor/types.ts
@@ -52,6 +52,11 @@ export interface Operator {
   description?: string;
 }
 
+export interface TableIdentifier {
+  table?: string;
+  schema?: string;
+}
+
 export interface SQLCompletionItemProvider
   extends Omit<monacoTypes.languages.CompletionItemProvider, 'provideCompletionItems'> {
   /**
@@ -101,9 +106,9 @@ export interface SQLCompletionItemProvider
    * @alpha
    */
   tables?: {
-    resolve: () => Promise<TableDefinition[]>;
+    resolve: (TableIdentifier: TableIdentifier) => Promise<TableDefinition[]>;
     // Allows providing a custom function for calculating the table name from the query. If not specified a default implemnentation is used.
-    parseName?: (t: LinkedToken) => string;
+    parseName?: (token: LinkedToken) => TableIdentifier;
   };
   /**
    * Allows providing a custom function for resolving table.
@@ -111,7 +116,7 @@ export interface SQLCompletionItemProvider
    * @alpha
    */
   columns?: {
-    resolve: (table: string) => Promise<ColumnDefinition[]>;
+    resolve: (identifier?: TableIdentifier) => Promise<ColumnDefinition[]>;
   };
 
   /**
@@ -184,6 +189,7 @@ export enum StatementPosition {
   AfterOrderByDirection = 'afterOrderByDirection',
   AfterIsOperator = 'afterIsOperator',
   AfterIsNotOperator = 'afterIsNotOperator',
+  AfterSchema = 'afterSchema',
 }
 
 export enum SuggestionKind {

--- a/src/sql-editor/utils/tokenUtils.ts
+++ b/src/sql-editor/utils/tokenUtils.ts
@@ -40,7 +40,6 @@ export const getNamespaceToken = (currentToken: LinkedToken | null) => {
   }
   return null;
 };
-
 export const getTableToken = (currentToken: LinkedToken | null) => {
   const fromToken = getFromKeywordToken(currentToken);
   const nextNonWhiteSpace = fromToken?.getNextNonWhiteSpaceToken();
@@ -52,5 +51,17 @@ export const getTableToken = (currentToken: LinkedToken | null) => {
   } else {
     return nextNonWhiteSpace;
   }
+  return null;
+};
+
+export const defaultTableNameParser = (token: LinkedToken) => {
+  const parts = token?.value.split('.');
+
+  if (parts?.length === 1) {
+    return { table: parts[0] };
+  } else if (parts?.length === 2) {
+    return { schema: parts[0], table: parts[1] };
+  }
+
   return null;
 };


### PR DESCRIPTION
Most SQL languages support prefixing the table name with a schema name. For example `select * from dbo.products`. This allows more sophisticated autocompletion. Currently, when a schema is specified the autocompletion engine doesn't take it into account. This is breaking suggestions for columns and causing other problems where the position detection is lost. 

This PR adds support for rich autocompletion in the case a schema is provided in the query. To enable this, I had to change the signature for the `tables` and the `columns` api in the completion item provider so that it no longer only passes the table name, but also the schema. This is a breaking change that needs to be handled in for example the big query data source. 

![schema-support](https://user-images.githubusercontent.com/2388950/180432671-886ad8e2-559e-48d8-a27b-bb6236672745.gif)

Next step could be to add an api for loading schemas so that they can be suggested too. 

