### PR TITLE
Add support for resolving schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.38",
+  "version": "0.0.2-canary.39",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "0.0.2-canary.37",
+  "version": "0.0.2-canary.38",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/sql-editor/components/SQLEditor.tsx
+++ b/src/sql-editor/components/SQLEditor.tsx
@@ -4,6 +4,7 @@ import { getStatementPosition } from '../standardSql/getStatementPosition';
 import { getStandardSuggestions } from '../standardSql/getStandardSuggestions';
 import { initSuggestionsKindRegistry, SuggestionKindRegistryItem } from '../standardSql/suggestionsKindRegistry';
 import {
+  CompletionItemInsertTextRule,
   CompletionItemKind,
   CompletionItemPriority,
   CustomSuggestion,
@@ -330,6 +331,23 @@ function extendStandardRegistries(id: string, lid: string, customProvider: SQLCo
     }
   }
 
+  if (customProvider.schemas) {
+    const stbBehaviour = instanceSuggestionsRegistry.get(SuggestionKind.Schemas);
+    const s = stbBehaviour.suggestions;
+    stbBehaviour.suggestions = async (ctx, m) => {
+      const standardSchemas = await s(ctx, m);
+      const customSchemas = await customProvider.schemas.resolve();
+      const customSchemaCompletionItems = customSchemas.map((x) => ({
+        label: x.name,
+        insertText: `${x.completion ?? x.name}.`,
+        command: TRIGGER_SUGGEST,
+        kind: CompletionItemKind.Module, // it's nice to differentiate schemas from tables
+        sortText: CompletionItemPriority.High,
+      }));
+      return [...standardSchemas, ...customSchemaCompletionItems];
+    };
+  }
+
   if (customProvider.tables) {
     const stbBehaviour = instanceSuggestionsRegistry.get(SuggestionKind.Tables);
     const s = stbBehaviour!.suggestions;
@@ -340,10 +358,12 @@ function extendStandardRegistries(id: string, lid: string, customProvider: SQLCo
       const tableIdentifier = tableNameParser(tableToken);
       const oo = (await customProvider.tables!.resolve!(tableIdentifier)).map((x) => ({
         label: x.name,
-        insertText: x.completion ?? x.name,
+        // if no custom completion is provided it's safe to move cursor further in the statement
+        insertText: `${x.completion ?? x.name}${x.completion === x.name ? ' $0' : ''}`,
+        insertTextRules: CompletionItemInsertTextRule.InsertAsSnippet,
         command: TRIGGER_SUGGEST,
         kind: CompletionItemKind.Field,
-        sortText: CompletionItemPriority.High,
+        sortText: CompletionItemPriority.MediumHigh,
       }));
       return [...o, ...oo];
     };

--- a/src/sql-editor/index.ts
+++ b/src/sql-editor/index.ts
@@ -6,6 +6,7 @@ export { getStandardSQLCompletionProvider } from './standardSql/standardSQLCompl
 export { SQLMonarchLanguage } from './standardSql/types';
 
 export {
+  SchemaDefinition,
   TableDefinition,
   ColumnDefinition,
   TableIdentifier,

--- a/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
+++ b/src/sql-editor/standardSql/standardSuggestionsRegistry.ts
@@ -196,6 +196,11 @@ export const initStandardSuggestions =
           ]),
       },
       {
+        id: SuggestionKind.Schemas,
+        name: SuggestionKind.Schemas,
+        suggestions: (_, m) => Promise.resolve([]),
+      },
+      {
         id: SuggestionKind.Tables,
         name: SuggestionKind.Tables,
         suggestions: (_, m) => Promise.resolve([]),

--- a/src/sql-editor/standardSql/suggestionsKindRegistry.ts
+++ b/src/sql-editor/standardSql/suggestionsKindRegistry.ts
@@ -52,7 +52,7 @@ export const initSuggestionsKindRegistry = (): SuggestionKindRegistryItem[] => {
     {
       id: StatementPosition.AfterFromKeyword,
       name: StatementPosition.AfterFromKeyword,
-      kind: [SuggestionKind.Tables, SuggestionKind.TableMacro],
+      kind: [SuggestionKind.Schemas, SuggestionKind.Tables, SuggestionKind.TableMacro],
     },
     {
       id: StatementPosition.AfterSchema,

--- a/src/sql-editor/types.ts
+++ b/src/sql-editor/types.ts
@@ -42,7 +42,7 @@ export interface ColumnDefinition {
 
 export interface SchemaDefinition {
   name: string;
-  // Text used for automplete. If not provided name is used.
+  // Text used for autocomplete. If not provided name is used.
   completion?: string;
 }
 

--- a/src/sql-editor/types.ts
+++ b/src/sql-editor/types.ts
@@ -39,6 +39,13 @@ export interface ColumnDefinition {
   // Text used for automplete. If not provided name is used.
   completion?: string;
 }
+
+export interface SchemaDefinition {
+  name: string;
+  // Text used for automplete. If not provided name is used.
+  completion?: string;
+}
+
 export interface TableDefinition {
   name: string;
   // Text used for automplete. If not provided name is used.
@@ -99,6 +106,15 @@ export interface SQLCompletionItemProvider
    * @alpha
    */
   customStatementPlacement?: StatementPlacementProvider;
+
+  /**
+   * Allows providing a custom function for resolving schemas.
+   * It's up to the consumer to decide whether the schemas are resolved via API calls or preloaded in the query editor(i.e. full db schema is preloades loaded).
+   * @alpha
+   */
+  schemas?: {
+    resolve: () => Promise<SchemaDefinition[]>;
+  };
 
   /**
    * Allows providing a custom function for resolving db tables.
@@ -193,6 +209,7 @@ export enum StatementPosition {
 }
 
 export enum SuggestionKind {
+  Schemas = 'schemas',
   Tables = 'tables',
   Columns = 'columns',
   SelectKeyword = 'selectKeyword',


### PR DESCRIPTION
This PR allows the consumer to optionally provide a method in the completion item provider to resolve schemas. 

This example demonstrates how it looks when used in the redshift data source. 
![schemas](https://user-images.githubusercontent.com/2388950/184880974-01d74002-fa1f-436b-8e5a-13cfba284e77.gif)

Also see how it's implemented in the redshift data source [here](https://github.com/grafana/redshift-datasource/pull/173). 

Sorry for the lack of tests in this PR - this is touching core parts of Monaco and there's currently no way of testing that. 