### PR TITLE
fix: make tooltip "tabable"

### DIFF
--- a/src/QueryEditor/EditorField.tsx
+++ b/src/QueryEditor/EditorField.tsx
@@ -30,7 +30,7 @@ export const EditorField: React.FC<EditorFieldProps> = (props) => {
         {optional && <span className={styles.optional}> - optional</span>}
         {tooltip && (
           <Tooltip placement="top" content={tooltip} theme="info" interactive={tooltipInteractive}>
-            <Icon name="info-circle" size="sm" className={styles.icon} />
+            <Icon tabIndex={0} name="info-circle" size="sm" className={styles.icon} />
           </Tooltip>
         )}
       </label>


### PR DESCRIPTION
Tooltips in `EditorField` should now be visible when tabbing through the interface.
- fixes grafana/grafana#56561
- Same fix as grafana/grafana#47137

![Peek 2022-10-26 15-55](https://user-images.githubusercontent.com/1048831/198124178-44279eb4-ff3b-486e-99b6-a49f11ac861a.gif)
