### PR TITLE
Add a ref to the Button in EditorList.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1.0
+
+- EditorList now accepts a ref to the Button for adding items
+
 ## v1.0.2
 
 - Make EditorField tooltip selectable via keyboard

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/QueryEditor/EditorList.tsx
+++ b/src/QueryEditor/EditorList.tsx
@@ -13,7 +13,10 @@ interface EditorListProps<T> {
   onChange: (items: Array<Partial<T>>) => void;
 }
 
-export function EditorList<T>({ items, renderItem, onChange }: EditorListProps<T>) {
+export const EditorList = React.forwardRef(function EditorList<T>(
+  { items, renderItem, onChange }: EditorListProps<T>,
+  ref: React.Ref<HTMLButtonElement>
+) {
   const onAddItem = () => {
     const newItems = [...items, {}];
 
@@ -42,7 +45,7 @@ export function EditorList<T>({ items, renderItem, onChange }: EditorListProps<T
           )}
         </div>
       ))}
-      <Button onClick={onAddItem} variant="secondary" size="md" icon="plus" aria-label="Add" type="button" />
+      <Button ref={ref} onClick={onAddItem} variant="secondary" size="md" icon="plus" aria-label="Add" type="button" />
     </Stack>
   );
-}
+});


### PR DESCRIPTION
EditorList renders everything via a render prop except for the button. Therefore to get a handle to that button I've used the [forwardRef][1] method to add a ref.

This is useful in my case because I wanted to set the `focus` state on the button when the `EditorList` was revealed in the DOM.

[1]: https://reactjs.org/docs/forwarding-refs.html