### PR TITLE
feat: add ConfigSection, ConfigSubSection and DataSourceDescription components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.2.0
+
+- Add new ConfigSection, ConfigSubSection and DataSourceDescription components
+
 ## v1.1.0
 
 - EditorList now accepts a ref to the Button for adding items

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ const config = standard.jestConfig();
 module.exports = {
   ...config,
   watchPathIgnorePatterns: ['<rootDir>/node_modules/'],
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^11.2.5",
     "@testing-library/react-hooks": "^5.1.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/node": "10.14.1",
     "@types/react": "16.8.16",
     "@types/react-test-renderer": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/ConfigEditor/ConfigSection/ConfigSection.test.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigSection.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { ConfigSection } from './ConfigSection';
+
+describe('<ConfigSection />', () => {
+  it('should render title as <h3>', () => {
+    render(
+      <ConfigSection title="Test title">
+        <div>Content</div>
+      </ConfigSection>
+    );
+
+    expect(screen.getByText('Test title').tagName).toBe('H3');
+  });
+});

--- a/src/ConfigEditor/ConfigSection/ConfigSection.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigSection.tsx
@@ -3,7 +3,7 @@ import { GenericConfigSection, Props as GenericConfigSectionProps } from './Gene
 
 type Props = Omit<GenericConfigSectionProps, 'kind'>;
 
-export const ConfigSection: React.FC<Props> = ({ children, ...props }) => {
+export const ConfigSection = ({ children, ...props }: Props) => {
   return (
     <GenericConfigSection {...props} kind="section">
       {children}

--- a/src/ConfigEditor/ConfigSection/ConfigSection.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigSection.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { GenericConfigSection, Props as GenericConfigSectionProps } from './GenericConfigSection';
+
+type Props = Omit<GenericConfigSectionProps, 'kind'>;
+
+export const ConfigSection: React.FC<Props> = ({ children, ...props }) => {
+  return (
+    <GenericConfigSection {...props} kind="section">
+      {children}
+    </GenericConfigSection>
+  );
+};

--- a/src/ConfigEditor/ConfigSection/ConfigSubSection.test.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigSubSection.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { ConfigSubSection } from './ConfigSubSection';
+
+describe('<ConfigSubSection />', () => {
+  it('should render title as <h3>', () => {
+    render(
+      <ConfigSubSection title="Test title">
+        <div>Content</div>
+      </ConfigSubSection>
+    );
+
+    expect(screen.getByText('Test title').tagName).toBe('H6');
+  });
+});

--- a/src/ConfigEditor/ConfigSection/ConfigSubSection.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigSubSection.tsx
@@ -3,7 +3,7 @@ import { GenericConfigSection, Props as GenericConfigSectionProps } from './Gene
 
 type Props = Omit<GenericConfigSectionProps, 'kind'>;
 
-export const ConfigSubSection: React.FC<Props> = ({ children, ...props }) => {
+export const ConfigSubSection = ({ children, ...props }: Props) => {
   return (
     <GenericConfigSection {...props} kind="sub-section">
       {children}

--- a/src/ConfigEditor/ConfigSection/ConfigSubSection.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigSubSection.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { GenericConfigSection, Props as GenericConfigSectionProps } from './GenericConfigSection';
+
+type Props = Omit<GenericConfigSectionProps, 'kind'>;
+
+export const ConfigSubSection: React.FC<Props> = ({ children, ...props }) => {
+  return (
+    <GenericConfigSection {...props} kind="sub-section">
+      {children}
+    </GenericConfigSection>
+  );
+};

--- a/src/ConfigEditor/ConfigSection/GenericConfigSection.test.tsx
+++ b/src/ConfigEditor/ConfigSection/GenericConfigSection.test.tsx
@@ -72,7 +72,7 @@ describe('<GenericConfigSection />', () => {
     expect(() => screen.getByLabelText('Collapse section Test title')).toThrow();
   });
 
-  it('should be collapsible with content visible when `isCollapsible` is `true` and `isOpen` is not passed', async () => {
+  it('should be collapsible with content visible when `isCollapsible` is `true` and `isInitiallyOpen` is not passed', async () => {
     render(
       <GenericConfigSection title="Test title" isCollapsible>
         <div>Test content</div>
@@ -86,9 +86,9 @@ describe('<GenericConfigSection />', () => {
     expect(() => screen.getByText('Test content')).toThrow();
   });
 
-  it('should be collapsible with content visible when `isCollapsible` is `true` and `isOpen` is `true`', async () => {
+  it('should be collapsible with content visible when `isCollapsible` is `true` and `isInitiallyOpen` is `true`', async () => {
     render(
-      <GenericConfigSection title="Test title" isCollapsible isOpen={true}>
+      <GenericConfigSection title="Test title" isCollapsible isInitiallyOpen={true}>
         <div>Test content</div>
       </GenericConfigSection>
     );
@@ -100,9 +100,9 @@ describe('<GenericConfigSection />', () => {
     expect(() => screen.getByText('Test content')).toThrow();
   });
 
-  it('should be collapsible with content hidden when `isCollapsible` is `true` and `isOpen` is `false`', async () => {
+  it('should be collapsible with content hidden when `isCollapsible` is `true` and `isInitiallyOpen` is `false`', async () => {
     render(
-      <GenericConfigSection title="Test title" isCollapsible isOpen={false}>
+      <GenericConfigSection title="Test title" isCollapsible isInitiallyOpen={false}>
         <div>Test content</div>
       </GenericConfigSection>
     );

--- a/src/ConfigEditor/ConfigSection/GenericConfigSection.test.tsx
+++ b/src/ConfigEditor/ConfigSection/GenericConfigSection.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { GenericConfigSection } from './GenericConfigSection';
+
+let user = userEvent.setup();
+
+describe('<GenericConfigSection />', () => {
+  beforeEach(() => {
+    userEvent.setup();
+  });
+
+  it('should render title', () => {
+    render(
+      <GenericConfigSection title="Test title">
+        <div>Content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test title')).toBeInTheDocument();
+  });
+
+  it('should render title as <h3> by default', () => {
+    render(
+      <GenericConfigSection title="Test title">
+        <div>Content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test title').tagName).toBe('H3');
+  });
+
+  it('should render title as <h3> when `kind` is `section`', () => {
+    render(
+      <GenericConfigSection title="Test title" kind="section">
+        <div>Content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test title').tagName).toBe('H3');
+  });
+
+  it('should render title as <h6> when `kind` is `sub-section`', () => {
+    render(
+      <GenericConfigSection title="Test title" kind="sub-section">
+        <div>Content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test title').tagName).toBe('H6');
+  });
+
+  it('should render description', () => {
+    render(
+      <GenericConfigSection title="Test title" description="Test description">
+        <div>Content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+  });
+
+  it('should not be collapsible by default', () => {
+    render(
+      <GenericConfigSection title="Test title">
+        <div>Test content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+    expect(() => screen.getByLabelText('Expand section Test title')).toThrow();
+    expect(() => screen.getByLabelText('Collapse section Test title')).toThrow();
+  });
+
+  it('should be collapsible with content visible when `isCollapsible` is `true` and `isOpen` is not passed', async () => {
+    render(
+      <GenericConfigSection title="Test title" isCollapsible>
+        <div>Test content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Collapse section Test title'));
+
+    expect(() => screen.getByText('Test content')).toThrow();
+  });
+
+  it('should be collapsible with content visible when `isCollapsible` is `true` and `isOpen` is `true`', async () => {
+    render(
+      <GenericConfigSection title="Test title" isCollapsible isOpen={true}>
+        <div>Test content</div>
+      </GenericConfigSection>
+    );
+
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Collapse section Test title'));
+
+    expect(() => screen.getByText('Test content')).toThrow();
+  });
+
+  it('should be collapsible with content hidden when `isCollapsible` is `true` and `isOpen` is `false`', async () => {
+    render(
+      <GenericConfigSection title="Test title" isCollapsible isOpen={false}>
+        <div>Test content</div>
+      </GenericConfigSection>
+    );
+
+    expect(() => screen.getByText('Test content')).toThrow();
+
+    await user.click(screen.getByLabelText('Expand section Test title'));
+
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('should have passed `className`', () => {
+    const { container } = render(
+      <GenericConfigSection title="Test title" className="test-class">
+        <div>Test content</div>
+      </GenericConfigSection>
+    );
+
+    expect(container.firstChild).toHaveClass('test-class');
+  });
+});

--- a/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
+++ b/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, ReactNode } from 'react';
 import { css } from '@emotion/css';
 import { useTheme2, IconButton, IconName } from '@grafana/ui';
 
@@ -9,9 +9,10 @@ export type Props = {
   isInitiallyOpen?: boolean;
   kind?: 'section' | 'sub-section';
   className?: string;
+  children: ReactNode;
 };
 
-export const GenericConfigSection: React.FC<Props> = ({
+export const GenericConfigSection = ({
   children,
   title,
   description,
@@ -19,7 +20,7 @@ export const GenericConfigSection: React.FC<Props> = ({
   isInitiallyOpen = true,
   kind = 'section',
   className,
-}) => {
+}: Props) => {
   const { colors, typography, spacing } = useTheme2();
   const [isOpen, setIsOpen] = useState(isCollapsible ? isInitiallyOpen : true);
   const iconName: IconName = isOpen ? 'angle-up' : 'angle-down';

--- a/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
+++ b/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
@@ -6,7 +6,7 @@ export type Props = {
   title: string;
   description?: string;
   isCollapsible?: boolean;
-  isOpen?: boolean;
+  isInitiallyOpen?: boolean;
   kind?: 'section' | 'sub-section';
   className?: string;
 };
@@ -16,7 +16,7 @@ export const GenericConfigSection: React.FC<Props> = ({
   title,
   description,
   isCollapsible = false,
-  isOpen: isInitiallyOpen = true,
+  isInitiallyOpen = true,
   kind = 'section',
   className,
 }) => {

--- a/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
+++ b/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/css';
+import { useTheme2, IconButton, IconName } from '@grafana/ui';
+
+export type Props = {
+  title: string;
+  description?: string;
+  isCollapsible?: boolean;
+  isOpen?: boolean;
+  kind?: 'section' | 'sub-section';
+  className?: string;
+};
+
+export const GenericConfigSection: React.FC<Props> = ({
+  children,
+  title,
+  description,
+  isCollapsible = false,
+  isOpen: isInitiallyOpen = true,
+  kind = 'section',
+  className,
+}) => {
+  const { colors, typography, spacing } = useTheme2();
+  const [isOpen, setIsOpen] = useState(isCollapsible ? isInitiallyOpen : true);
+  const iconName: IconName = isOpen ? 'angle-up' : 'angle-down';
+  const isSubSection = kind === 'sub-section';
+  const collapsibleButtonAriaLabel = `${isOpen ? 'Collapse' : 'Expand'} section ${title}`;
+
+  const styles = {
+    header: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }),
+    title: css({
+      margin: 0,
+    }),
+    subtitle: css({
+      margin: 0,
+      fontWeight: typography.fontWeightRegular,
+    }),
+    descriptionText: css({
+      marginTop: spacing(isSubSection ? 0.25 : 0.5),
+      marginBottom: 0,
+      ...typography.bodySmall,
+      color: colors.text.secondary,
+    }),
+    content: css({
+      marginTop: spacing(2),
+    }),
+  };
+
+  return (
+    <div className={className}>
+      <div className={styles.header}>
+        {kind === 'section' ? <h3 className={styles.title}>{title}</h3> : <h6 className={styles.subtitle}>{title}</h6>}
+        {isCollapsible && (
+          <IconButton
+            name={iconName}
+            onClick={() => setIsOpen(!isOpen)}
+            type="button"
+            size="xl"
+            aria-label={collapsibleButtonAriaLabel}
+          />
+        )}
+      </div>
+      {description && <p className={styles.descriptionText}>{description}</p>}
+      {isOpen && <div className={styles.content}>{children}</div>}
+    </div>
+  );
+};

--- a/src/ConfigEditor/ConfigSection/index.ts
+++ b/src/ConfigEditor/ConfigSection/index.ts
@@ -1,0 +1,2 @@
+export { ConfigSection } from './ConfigSection';
+export { ConfigSubSection } from './ConfigSubSection';

--- a/src/ConfigEditor/DataSourceDescription.test.tsx
+++ b/src/ConfigEditor/DataSourceDescription.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { DataSourceDescription } from './DataSourceDescription';
+import { render } from '@testing-library/react';
+
+describe('<DataSourceDescription />', () => {
+  it('should render data source name', () => {
+    const dataSourceName = 'Test data source name';
+    const { getByText } = render(
+      <DataSourceDescription dataSourceName={dataSourceName} docsLink="https://grafana.com/test-datasource-docs" />
+    );
+
+    expect(getByText(dataSourceName, { exact: false })).toBeInTheDocument();
+  });
+
+  it('should render docs link', () => {
+    const docsLink = 'https://grafana.com/test-datasource-docs';
+    const { getByText } = render(
+      <DataSourceDescription dataSourceName={'Test data source name'} docsLink={docsLink} />
+    );
+
+    const docsLinkEl = getByText('view the documentation');
+
+    expect(docsLinkEl.getAttribute('href')).toBe(docsLink);
+  });
+
+  it('should render text about required fields by default', () => {
+    const { getByText } = render(
+      <DataSourceDescription
+        dataSourceName={'Test data source name'}
+        docsLink={'https://grafana.com/test-datasource-docs'}
+      />
+    );
+
+    expect(getByText('Fields marked in', { exact: false })).toBeInTheDocument();
+  });
+
+  it('should not render text about required fields when `hasRequiredFields` props is `false`', () => {
+    const { getByText } = render(
+      <DataSourceDescription
+        dataSourceName={'Test data source name'}
+        docsLink={'https://grafana.com/test-datasource-docs'}
+        hasRequiredFields={false}
+      />
+    );
+
+    expect(() => getByText('Fields marked in', { exact: false })).toThrow();
+  });
+});

--- a/src/ConfigEditor/DataSourceDescription.tsx
+++ b/src/ConfigEditor/DataSourceDescription.tsx
@@ -8,7 +8,7 @@ type Props = {
   hasRequiredFields?: boolean;
 };
 
-export const DataSourceDescription: React.FC<Props> = ({ dataSourceName, docsLink, hasRequiredFields = true }) => {
+export const DataSourceDescription = ({ dataSourceName, docsLink, hasRequiredFields = true }: Props) => {
   const theme = useTheme2();
 
   const styles = {

--- a/src/ConfigEditor/DataSourceDescription.tsx
+++ b/src/ConfigEditor/DataSourceDescription.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { useTheme2 } from '@grafana/ui';
+
+type Props = {
+  dataSourceName: string;
+  docsLink: string;
+  hasRequiredFields?: boolean;
+};
+
+export const DataSourceDescription: React.FC<Props> = ({ dataSourceName, docsLink, hasRequiredFields = true }) => {
+  const theme = useTheme2();
+
+  const styles = {
+    container: css({
+      margin: theme.spacing(4, 0),
+    }),
+    text: css({
+      ...theme.typography.body,
+      color: theme.colors.text.secondary,
+      a: css({
+        color: theme.colors.text.link,
+        textDecoration: 'underline',
+        '&:hover': {
+          textDecoration: 'none',
+        },
+      }),
+    }),
+    asterisk: css`
+      color: ${theme.colors.error.main};
+    `,
+  };
+
+  return (
+    <div className={styles.container}>
+      <p className={styles.text}>
+        Before you can use the {dataSourceName} data source, you must configure it below or in the config file.
+        <br />
+        For detailed instructions,{' '}
+        <a href={docsLink} target="_blank" rel="noreferrer">
+          view the documentation
+        </a>
+        .
+      </p>
+      {hasRequiredFields && (
+        <p className={styles.text}>
+          <i>
+            Fields marked in <span className={styles.asterisk}>*</span> are required
+          </i>
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/ConfigEditor/index.ts
+++ b/src/ConfigEditor/index.ts
@@ -1,0 +1,2 @@
+export { DataSourceDescription } from './DataSourceDescription';
+export * from './ConfigSection';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './sql-editor';
 export * from './QueryEditor';
+export * from './ConfigEditor';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,11 @@
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"
 
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
### About the change

Adding new `ConfigSection`, `ConfigSubSection` and `DataSourceDescription` components that are meant to be used in data source config editor.

Adding here so that they can be used in both Grafana core and external plugins.

`DataSourceDescription` appeared first in [Grafana core PR](https://github.com/grafana/grafana/pull/67207), but after discussions we decided that it's better to place it elsewhere.

_This is a part of a config redesign project._

### Screenshots:

**DataSourceDescription**:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1436174/234284222-49484373-9834-4d95-aa7b-aaee3e25c5ed.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1436174/234284471-c6460c47-bc01-4c19-8f6d-430e4b0ca3c8.png">

**ConfgSection** and **ConfgSubSection**:

> Note: `<hr/>` is not a part of a section component and is present in the screenshot just for illustration purposes.

![image](https://user-images.githubusercontent.com/1436174/235142234-238ee471-1bc2-4ad0-a256-ae9045b27f9f.png)

Closes https://github.com/grafana/enterprise-datasources/issues/218