### PR TITLE
feat: Minor changes to DataSourceDescription component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.0
+
+- `DataSourceDescription` config editor component: added possibility to pass `className` + minor styling changes
+
 ## v1.3.0
 
 - Add Auth component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/ConfigEditor/DataSourceDescription.test.tsx
+++ b/src/ConfigEditor/DataSourceDescription.test.tsx
@@ -45,4 +45,16 @@ describe('<DataSourceDescription />', () => {
 
     expect(() => getByText('Fields marked in', { exact: false })).toThrow();
   });
+
+  it('should render passed `className`', () => {
+    const { container } = render(
+      <DataSourceDescription
+        dataSourceName={'Test data source name'}
+        docsLink={'https://grafana.com/test-datasource-docs'}
+        className="test-class-name"
+      />
+    );
+
+    expect(container.firstChild).toHaveClass('test-class-name');
+  });
 });

--- a/src/ConfigEditor/DataSourceDescription.tsx
+++ b/src/ConfigEditor/DataSourceDescription.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
-import { css } from '@emotion/css';
+import { cx, css } from '@emotion/css';
 import { useTheme2 } from '@grafana/ui';
 
 type Props = {
   dataSourceName: string;
   docsLink: string;
   hasRequiredFields?: boolean;
+  className?: string;
 };
 
-export const DataSourceDescription = ({ dataSourceName, docsLink, hasRequiredFields = true }: Props) => {
+export const DataSourceDescription = ({ dataSourceName, docsLink, hasRequiredFields = true, className }: Props) => {
   const theme = useTheme2();
 
   const styles = {
     container: css({
-      margin: theme.spacing(4, 0),
+      p: {
+        margin: 0,
+      },
+      'p + p': {
+        marginTop: theme.spacing(2),
+      },
     }),
     text: css({
       ...theme.typography.body,
@@ -32,11 +38,10 @@ export const DataSourceDescription = ({ dataSourceName, docsLink, hasRequiredFie
   };
 
   return (
-    <div className={styles.container}>
+    <div className={cx(styles.container, className)}>
       <p className={styles.text}>
-        Before you can use the {dataSourceName} data source, you must configure it below or in the config file.
-        <br />
-        For detailed instructions,{' '}
+        Before you can use the {dataSourceName} data source, you must configure it below or in the config file. For
+        detailed instructions,{' '}
         <a href={docsLink} target="_blank" rel="noreferrer">
           view the documentation
         </a>


### PR DESCRIPTION
We decided to remove outer margin from the DataSourceDescription component and enabled adding custom `className` if someone will need to add extra styles.

Also, line break in the text got removed after communication with designer.