### PR TITLE
fix: Fix types for Auth component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.1
+
+- Fix types for `Auth` component - allow any `jsonData`
+
 ## v1.4.0
 
 - `DataSourceDescription` config editor component: added possibility to pass `className` + minor styling changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/ConfigEditor/Auth/utils.ts
+++ b/src/ConfigEditor/Auth/utils.ts
@@ -5,13 +5,13 @@ import { AuthMethod, Header, CustomMethodId } from './types';
 const headerNamePrefix = 'httpHeaderName';
 const headerValuePrefix = 'httpHeaderValue';
 
-type onChangeHandler = (config: DataSourceSettings) => void;
+type onChangeHandler = (config: DataSourceSettings<any, any>) => void;
 
 export function convertLegacyAuthProps({
   config,
   onChange,
 }: {
-  config: DataSourceSettings;
+  config: DataSourceSettings<any, any>;
   onChange: onChangeHandler;
 }): AuthProps {
   const props: AuthProps = {


### PR DESCRIPTION
Allowing any `jsonData`. This is to avoid issues like this when using the package:

![image](https://github.com/grafana/grafana-experimental/assets/1436174/1fb2e44b-e77b-429b-a701-79900fefb177)

[Similar approach is used in the legacy component](https://github.com/grafana/grafana/blob/58aa098ed77902a3bad80180bf314826a407304f/packages/grafana-ui/src/components/DataSourceSettings/types.ts#L22).