### PR TITLE
Update GenericConfigSection description type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.4.2
+
+- Update `GenericConfigSection` component type for prop `description` to `ReactNode`
+
 ## v1.4.1
 
 - Fix types for `Auth` component - allow any `jsonData`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Experimental Grafana components and APIs",
   "main": "index.js",
   "types": "dist/index.d.ts",

--- a/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
+++ b/src/ConfigEditor/ConfigSection/GenericConfigSection.tsx
@@ -4,7 +4,7 @@ import { useTheme2, IconButton, IconName } from '@grafana/ui';
 
 export type Props = {
   title: string;
-  description?: string;
+  description?: ReactNode;
   isCollapsible?: boolean;
   isInitiallyOpen?: boolean;
   kind?: 'section' | 'sub-section';


### PR DESCRIPTION
Updates the `GenericConfigSection` description prop to be of type `ReactNode`. This is so consumers of this component can pass more than just text to the component e.g. a description string with a link to documentation.