### PR TITLE
Fix publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: '16'
           cache: 'yarn'
-      - run: yarn
+      - run: yarn install --immutable --prefer-offline
       - run: yarn lint
       - run: yarn typecheck
       - run: yarn jest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
       # limit releases to version changes - https://github.com/EndBug/version-check
@@ -27,15 +27,16 @@ jobs:
 
       - name: Setup .npmrc file for NPM registry
         if: steps.version_check.outputs.changed == 'true'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
+          cache: 'yarn'
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'
-        run: yarn
-        
+        run: yarn install --immutable --prefer-offline
+
       - name: Build library
         if: steps.version_check.outputs.changed == 'true'
         run: yarn build


### PR DESCRIPTION
Having merged #56 we now have [failing publish workflows](https://github.com/grafana/grafana-experimental/actions/runs/5066596012/jobs/9096594648) due to the version of node being used.

This PR fixes that and makes better use of yarn cache to speed up dependency installs.

It would be nice to move away from this publishing workflow in favour of a workflow like used in levitate or switching to auto as is now being used in plugin-tools and scenes repos.