### PR TITLE
fix: fix Auth component for usages in Grafana 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.5.1
+
+- Fix Auth component to prevent it from failing when it is used in Grafana 8
+
 ## v1.5.0
 
 - Introduce treeshaking by rewriting rollup build configs to include both cjs and esm builds

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/ConfigEditor/Auth/auth-method/BasicAuth.tsx
+++ b/src/ConfigEditor/Auth/auth-method/BasicAuth.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cx, css } from '@emotion/css';
-import { InlineField, Input, SecretInput, PopoverContent } from '@grafana/ui';
+import { InlineField, Input, PopoverContent } from '@grafana/ui';
+import { SecretInput } from '../common';
 import { useCommonStyles } from '../styles';
 
 export type Props = {

--- a/src/ConfigEditor/Auth/common/SecretInput.tsx
+++ b/src/ConfigEditor/Auth/common/SecretInput.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copy & paste from https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/SecretInput/SecretInput.tsx
+ * Available starting from @grafana/ui 9.2
+ * Needed, because Auth component is also used in Grafana 8, which doesn't have SecretInput
+ */
+
+import * as React from 'react';
+import { HorizontalGroup, Input, Button } from '@grafana/ui';
+
+export type Props = React.ComponentProps<typeof Input> & {
+  /** TRUE if the secret was already configured. (It is needed as often the backend doesn't send back the actual secret, only the information that it was configured) */
+  isConfigured: boolean;
+  /** Called when the user clicks on the "Reset" button in order to clear the secret */
+  onReset: () => void;
+};
+
+export const CONFIGURED_TEXT = 'configured';
+export const RESET_BUTTON_TEXT = 'Reset';
+
+export const SecretInput = ({ isConfigured, onReset, ...props }: Props) => (
+  <HorizontalGroup>
+    {!isConfigured && <Input {...props} type="password" />}
+    {isConfigured && <Input {...props} type="text" disabled={true} value={CONFIGURED_TEXT} />}
+    {isConfigured && (
+      <Button onClick={onReset} variant="secondary">
+        {RESET_BUTTON_TEXT}
+      </Button>
+    )}
+  </HorizontalGroup>
+);

--- a/src/ConfigEditor/Auth/common/SecretTextarea.tsx
+++ b/src/ConfigEditor/Auth/common/SecretTextarea.tsx
@@ -1,0 +1,52 @@
+/**
+ * Copy & paste from https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/SecretTextArea/SecretTextArea.tsx
+ * Available starting from @grafana/ui 9.2
+ * Needed, because Auth component is also used in Grafana 8, which doesn't have SecretTextarea
+ */
+
+import { css, cx } from '@emotion/css';
+import * as React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2, Button, TextArea, HorizontalGroup } from '@grafana/ui';
+
+export type Props = React.ComponentProps<typeof TextArea> & {
+  /** TRUE if the secret was already configured. (It is needed as often the backend doesn't send back the actual secret, only the information that it was configured) */
+  isConfigured: boolean;
+  /** Called when the user clicks on the "Reset" button in order to clear the secret */
+  onReset: () => void;
+};
+
+export const CONFIGURED_TEXT = 'configured';
+export const RESET_BUTTON_TEXT = 'Reset';
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    configuredStyle: css`
+      min-height: ${theme.spacing(theme.components.height.md)};
+      padding-top: ${theme.spacing(0.5) /** Needed to mimic vertically centered text in an input box */};
+      resize: none;
+    `,
+  };
+};
+
+/**
+ * Text area that does not disclose an already configured value but lets the user reset the current value and enter a new one.
+ * Typically useful for asymmetric cryptography keys.
+ */
+export const SecretTextArea = ({ isConfigured, onReset, ...props }: Props) => {
+  const styles = useStyles2(getStyles);
+  return (
+    <HorizontalGroup>
+      {!isConfigured && <TextArea {...props} />}
+      {isConfigured && (
+        <TextArea {...props} rows={1} disabled={true} value={CONFIGURED_TEXT} className={cx(styles.configuredStyle)} />
+      )}
+      {isConfigured && (
+        <Button onClick={onReset} variant="secondary">
+          {RESET_BUTTON_TEXT}
+        </Button>
+      )}
+    </HorizontalGroup>
+  );
+};

--- a/src/ConfigEditor/Auth/common/index.ts
+++ b/src/ConfigEditor/Auth/common/index.ts
@@ -1,0 +1,2 @@
+export { SecretInput } from './SecretInput';
+export { SecretTextArea } from './SecretTextarea';

--- a/src/ConfigEditor/Auth/custom-headers/CustomHeader.tsx
+++ b/src/ConfigEditor/Auth/custom-headers/CustomHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { css, cx } from '@emotion/css';
-import { InlineFieldRow, InlineField, Input, IconButton, useTheme2, SecretInput } from '@grafana/ui';
+import { InlineFieldRow, InlineField, Input, IconButton, useTheme2 } from '@grafana/ui';
+import { SecretInput } from '../common';
 import type { LocalHeader } from '../types';
 import { useCommonStyles } from '../styles';
 

--- a/src/ConfigEditor/Auth/tls/SelfSignedCertificate.tsx
+++ b/src/ConfigEditor/Auth/tls/SelfSignedCertificate.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cx } from '@emotion/css';
-import { InlineField, SecretTextArea } from '@grafana/ui';
+import { InlineField } from '@grafana/ui';
+import { SecretTextArea } from '../common';
 import { TLSSettingsSection } from './TLSSettingsSection';
 import { useCommonStyles } from '../styles';
 

--- a/src/ConfigEditor/Auth/tls/TLSClientAuth.tsx
+++ b/src/ConfigEditor/Auth/tls/TLSClientAuth.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cx } from '@emotion/css';
-import { InlineField, Input, SecretTextArea } from '@grafana/ui';
+import { InlineField, Input } from '@grafana/ui';
+import { SecretTextArea } from '../common';
 import { TLSSettingsSection } from './TLSSettingsSection';
 import { useCommonStyles } from '../styles';
 

--- a/src/ConfigEditor/Auth/utils.test.ts
+++ b/src/ConfigEditor/Auth/utils.test.ts
@@ -1,4 +1,3 @@
-import { DataSourceSettings } from '@grafana/data';
 import {
   getSelectedMethod,
   getOnAuthMethodSelectHandler,
@@ -6,6 +5,7 @@ import {
   getTLSProps,
   getCustomHeaders,
   convertLegacyAuthProps,
+  Config,
 } from './utils';
 import { Props as AuthProps } from './Auth';
 import { AuthMethod } from './types';
@@ -33,7 +33,7 @@ describe('utils', () => {
           httpHeaderValue2: true,
         },
         readOnly: true,
-      } as unknown as DataSourceSettings<any, any>;
+      } as unknown as Config;
       const onChange = jest.fn();
       const newProps = convertLegacyAuthProps({ config, onChange });
       const expected: AuthProps = {
@@ -87,39 +87,39 @@ describe('utils', () => {
 
   describe('getSelectedMethod', () => {
     it('should return basic auth selected method', () => {
-      const res = getSelectedMethod({ basicAuth: true } as DataSourceSettings);
+      const res = getSelectedMethod({ basicAuth: true } as Config);
       expect(res).toBe(AuthMethod.BasicAuth);
     });
 
     it('should return cross site credentials selected method', () => {
       const res = getSelectedMethod({
         withCredentials: true,
-      } as DataSourceSettings);
+      } as Config);
       expect(res).toBe(AuthMethod.CrossSiteCredentials);
     });
 
     it('should return OAuth forward selected method', () => {
       const res = getSelectedMethod({
         jsonData: { oauthPassThru: true },
-      } as DataSourceSettings<any>);
+      } as Config);
       expect(res).toBe(AuthMethod.OAuthForward);
     });
 
     it('should return no auth selected method', () => {
       const res = getSelectedMethod({
         jsonData: {},
-      } as DataSourceSettings<any>);
+      } as Config);
       expect(res).toBe(AuthMethod.NoAuth);
     });
   });
 
   describe('getOnAuthMethodSelectHandler', () => {
-    let config: DataSourceSettings<any, any>;
+    let config: Config;
     let onChange: jest.Mock<any, any>;
 
     beforeEach(() => {
       onChange = jest.fn();
-      config = {} as DataSourceSettings;
+      config = {} as Config;
     });
     it('should return correct onAuthMethodSelect handler', () => {
       const onAuthMethodSelect = getOnAuthMethodSelectHandler(config, onChange);
@@ -190,7 +190,7 @@ describe('utils', () => {
   });
 
   describe('getBasicAuthProps', () => {
-    let config: DataSourceSettings<any, any>;
+    let config: Config;
     let onChange: jest.Mock<any, any>;
 
     beforeEach(() => {
@@ -199,7 +199,7 @@ describe('utils', () => {
         secureJsonFields: {
           basicAuthPassword: false,
         },
-      } as unknown as DataSourceSettings<any, any>;
+      } as unknown as Config;
       onChange = jest.fn();
     });
 
@@ -265,7 +265,7 @@ describe('utils', () => {
   });
 
   describe('getTLSProps', () => {
-    let config: DataSourceSettings<any, any>;
+    let config: Config;
     let onChange: jest.Mock<any, any>;
 
     beforeEach(() => {
@@ -281,7 +281,7 @@ describe('utils', () => {
           tlsClientCert: false,
           tlsClientKey: false,
         },
-      } as unknown as DataSourceSettings<any, any>;
+      } as unknown as Config;
       onChange = jest.fn();
     });
 
@@ -464,7 +464,7 @@ describe('utils', () => {
   });
 
   describe('getCustomHeaders', () => {
-    let config: DataSourceSettings<any, any>;
+    let config: Config;
     let onChange: jest.Mock<any, any>;
 
     beforeEach(() => {
@@ -477,7 +477,7 @@ describe('utils', () => {
           httpHeaderValue1: false,
           httpHeaderValue2: true,
         },
-      } as unknown as DataSourceSettings<any, any>;
+      } as unknown as Config;
       onChange = jest.fn();
     });
 

--- a/src/ConfigEditor/Auth/utils.ts
+++ b/src/ConfigEditor/Auth/utils.ts
@@ -1,32 +1,36 @@
-import { DataSourceSettings } from '@grafana/data';
+import { DataSourceSettings, DataSourceJsonData } from '@grafana/data';
 import { Props as AuthProps } from './Auth';
 import { AuthMethod, Header, CustomMethodId } from './types';
 
 const headerNamePrefix = 'httpHeaderName';
 const headerValuePrefix = 'httpHeaderValue';
 
-type onChangeHandler = (config: DataSourceSettings<any, any>) => void;
+export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = any> = DataSourceSettings<
+  JSONData,
+  SecureJSONData
+>;
+export type OnChangeHandler<C extends Config = Config> = (config: C) => void;
 
-export function convertLegacyAuthProps({
+export function convertLegacyAuthProps<C extends Config = Config>({
   config,
   onChange,
 }: {
-  config: DataSourceSettings<any, any>;
-  onChange: onChangeHandler;
+  config: C;
+  onChange: OnChangeHandler<C>;
 }): AuthProps {
   const props: AuthProps = {
-    selectedMethod: getSelectedMethod(config),
-    onAuthMethodSelect: getOnAuthMethodSelectHandler(config, onChange),
-    basicAuth: getBasicAuthProps(config, onChange),
-    TLS: getTLSProps(config, onChange),
-    customHeaders: getCustomHeaders(config, onChange),
+    selectedMethod: getSelectedMethod<C>(config),
+    onAuthMethodSelect: getOnAuthMethodSelectHandler<C>(config, onChange),
+    basicAuth: getBasicAuthProps<C>(config, onChange),
+    TLS: getTLSProps<C>(config, onChange),
+    customHeaders: getCustomHeaders<C>(config, onChange),
     readOnly: config.readOnly,
   };
 
   return props;
 }
 
-export function getSelectedMethod(config: DataSourceSettings<any, any>): AuthMethod {
+export function getSelectedMethod<C extends Config = Config>(config: C): AuthMethod {
   if (config.basicAuth) {
     return AuthMethod.BasicAuth;
   }
@@ -39,9 +43,9 @@ export function getSelectedMethod(config: DataSourceSettings<any, any>): AuthMet
   return AuthMethod.NoAuth;
 }
 
-export function getOnAuthMethodSelectHandler(
-  config: DataSourceSettings<any, any>,
-  onChange: onChangeHandler
+export function getOnAuthMethodSelectHandler<C extends Config = Config>(
+  config: C,
+  onChange: OnChangeHandler<C>
 ): (method: AuthMethod | CustomMethodId) => void {
   return (method: AuthMethod | CustomMethodId) => {
     onChange({
@@ -56,9 +60,9 @@ export function getOnAuthMethodSelectHandler(
   };
 }
 
-export function getBasicAuthProps(
-  config: DataSourceSettings<any, any>,
-  onChange: (config: DataSourceSettings<any, any>) => void
+export function getBasicAuthProps<C extends Config = Config>(
+  config: C,
+  onChange: OnChangeHandler<C>
 ): AuthProps['basicAuth'] {
   return {
     user: config.basicAuthUser,
@@ -84,7 +88,7 @@ export function getBasicAuthProps(
   };
 }
 
-export function getTLSProps(config: DataSourceSettings<any, any>, onChange: onChangeHandler): AuthProps['TLS'] {
+export function getTLSProps<C extends Config = Config>(config: C, onChange: OnChangeHandler<C>): AuthProps['TLS'] {
   return {
     selfSignedCertificate: {
       enabled: Boolean(config.jsonData.tlsAuthWithCACert),
@@ -173,9 +177,9 @@ export function getTLSProps(config: DataSourceSettings<any, any>, onChange: onCh
   };
 }
 
-export function getCustomHeaders(
-  config: DataSourceSettings<any, any>,
-  onChange: onChangeHandler
+export function getCustomHeaders<C extends Config = Config>(
+  config: C,
+  onChange: OnChangeHandler<C>
 ): AuthProps['customHeaders'] {
   const headers: Header[] = Object.keys(config.jsonData)
     .filter((key) => key.startsWith(headerNamePrefix))


### PR DESCRIPTION
- Copied & pasted `SecretInput` and `SecretTextarea` from `@grafana/ui` to Auth component and using them from there instead of from `@grafana/ui` directly. This is because secret inputs are only available starting from `@grafana/ui` v9.2, but the Auth component can still be used in Grafana 8 environment which uses `@grafana/ui` v8.
- Fixed types of Auth component to also account for Grafana 8 types. In Grafana 8 `DataSourceSettings` type contains fields `password: string` and `basicAuthPassword: string`, which are not present in later Grafana versions. This caused type failures in enterprise plugins, because in the code they still rely on Grafana 8.