### PR TITLE
Make overriding built-in auth methods displayed properties possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.6.2
+
+- #Feature: Allow customizing the list of built-in authentication methods
+
 ## v1.6.1
 
 - Fix type changes in EditorList

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ For a component to be ready to move to the grafana/ui package, the following cri
 - Each component needs type definitions.
 - Requires good test coverage. Some of the grafana/experimental components don't currently have comprehensive tests.
 - It needs to have a low probability of a breaking change in the short/medium future. For instance, if it needs a new feature that will likely require a breaking change, it may be preferable to delay it being added to grafana/ui.
+
+# CONTRIBUTING
+
+As we are planning to get this repository to a more stable state please please write tests for your components.
+
+If you want to use your local development version in another repo run `yarn add link:"/yar/path/to/grafana-experimental"`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/ConfigEditor/Auth/Auth.tsx
+++ b/src/ConfigEditor/Auth/Auth.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from '@emotion/css';
-import { AuthMethod, CustomMethod, CustomMethodId } from './types';
+import { AuthMethod, DefaultAuthMethod, CustomMethod, CustomMethodId } from './types';
 import { AuthMethodSettings } from './auth-method/AuthMethodSettings';
 import { TLSSettings, Props as TLSSettingsProps } from './tls/TLSSettings';
 import { Props as BasicAuthProps } from './auth-method/BasicAuth';
@@ -11,6 +11,7 @@ export type Props = {
   selectedMethod: AuthMethod | CustomMethodId;
   mostCommonMethod?: AuthMethod | CustomMethodId;
   visibleMethods?: Array<AuthMethod | CustomMethodId>;
+  extendedDefaultOptions?: Partial<Record<AuthMethod, DefaultAuthMethod>>;
   customMethods?: CustomMethod[];
   onAuthMethodSelect: (authType: AuthMethod | CustomMethodId) => void;
   basicAuth?: Omit<BasicAuthProps, 'readOnly'>;
@@ -23,6 +24,7 @@ export const Auth: React.FC<Props> = ({
   selectedMethod,
   mostCommonMethod,
   visibleMethods,
+  extendedDefaultOptions,
   customMethods,
   onAuthMethodSelect,
   basicAuth,
@@ -44,6 +46,7 @@ export const Auth: React.FC<Props> = ({
           mostCommonMethod={mostCommonMethod}
           customMethods={customMethods}
           visibleMethods={visibleMethods}
+          extendedDefaultOptions={extendedDefaultOptions}
           onAuthMethodSelect={onAuthMethodSelect}
           basicAuth={basicAuth}
           readOnly={readOnly}

--- a/src/ConfigEditor/Auth/README.md
+++ b/src/ConfigEditor/Auth/README.md
@@ -61,6 +61,10 @@ type Props = {
   // Can also be used for reordering the list of auth methods.
   visibleMethods?: (AuthMethod | CustomMethodId)[];
 
+  // Allows overriding name and description properties of the built-in
+  // authentication methods that are displayed in the selection dropdown
+  extendDefaultOptions?: Partial<Record<AuthMethod, DefaultAuthMethod>>
+
   // Allows to render custom auth methods alongside default ones.
   // It is also possible to render only custom auth methods.
   customMethods?: {
@@ -155,6 +159,49 @@ type HeaderWithValue = Header & { value: string };
 If `TLS` is not passed, the TLS settings section will not be rendered.
 
 If `customHeaders` is not passed, custom headers section will not be rendered.
+
+## Mixing old and new style props
+
+In some cases you might want to use the `convertLegacyAuthProps` helper to create base properties that can then be extended with custom parameters. This is useful when the provisioning file used has similar structure to the one defined in ()[]. It can make using the `Auth` component extremely easy and still provide enough flexibility to customize it for your needs. For instance using the `BasicAuth` we can change it's name and description shown in the dropdown, as well as tooltips.
+
+```ts
+import { Auth, AuthMethod, convertLegacyAuthProps } from '@grafana/experimental';
+
+export const ConfigEditor = ({ options, onOptionsChange }) => {
+  const AuthMethodsList = [AuthMethod.NoAuth, AuthMethod.BasicAuth];
+
+  const convertedProps = convertLegacyAuthProps({
+    config: props.options,
+    onChange: onOptionsChange
+  });
+  const newAuthProps = {
+    ...convertedProps,
+    basicAuth: {
+      ...convertedProps.basicAuth,
+      userTooltip: 'The user is the username assigned to the MongoDB account.',
+      passwordTooltip: 'The password is the password assigned to the MongoDB account.',
+    }
+  };
+  const extendDefaultAuth = {
+    [AuthMethod.BasicAuth]: {
+      label: 'Credentials',
+      description: 'Authenticate with default credentials assigned to the MongoDB account upon creation.'
+    },
+  };
+
+  return (
+    <div>
+      <Auth
+        {...newAuthProps}
+        extendedDefaultOptions={extendDefaultAuth}
+        visibleMethods={AuthMethodsList}
+        // when custom headers section should not be visible and props were converted using the helper function it is required to set the value to null
+        customHeaders={null}
+      />
+    </div>
+  );
+};
+```
 
 ## Adding your own auth methods
 

--- a/src/ConfigEditor/Auth/auth-method/AuthMethodSettings.test.tsx
+++ b/src/ConfigEditor/Auth/auth-method/AuthMethodSettings.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { screen, render, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AuthMethodSettings, Props } from './AuthMethodSettings';
-import { AuthMethod } from '../types';
+import { AuthMethod, DefaultAuthMethod } from '../types';
 
 type PartialProps = Partial<Omit<Props, 'basicAuth'> & { basicAuth?: Partial<Props['basicAuth']> }>;
 const getProps = (partialProps?: PartialProps): Props => ({
@@ -27,6 +27,16 @@ describe('<AuthMethodSettings />', () => {
     expect(screen.getByText('Basic authentication')).toBeInTheDocument();
     expect(() => screen.getByText('Forward OAuth Identity')).toThrow();
     expect(() => screen.getByText('No Authentication')).toThrow();
+  });
+
+  it('should override Basic auth name and display it', async () => {
+    const props = getProps({
+      selectedMethod: AuthMethod.BasicAuth,
+      extendedDefaultOptions: { [AuthMethod.BasicAuth]: { label: 'Override '} } as Record<AuthMethod, DefaultAuthMethod>,
+    });
+    render(<AuthMethodSettings {...props} />);
+
+    expect(screen.getByText('Override')).toBeInTheDocument();
   });
 
   it('should render all default available auth methods when select is open', async () => {

--- a/src/ConfigEditor/Auth/auth-method/AuthMethodSettings.tsx
+++ b/src/ConfigEditor/Auth/auth-method/AuthMethodSettings.tsx
@@ -4,7 +4,7 @@ import { useTheme2, Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { BasicAuth, Props as BasicAuthProps } from './BasicAuth';
 import { ConfigSubSection } from '../../ConfigSection';
-import { AuthMethod, CustomMethod, CustomMethodId } from '../types';
+import { AuthMethod, CustomMethod, CustomMethodId , DefaultAuthMethod } from '../types';
 
 const defaultOptions: Record<AuthMethod, SelectableValue<AuthMethod>> = {
   [AuthMethod.BasicAuth]: {
@@ -35,6 +35,7 @@ export type Props = {
   selectedMethod: AuthMethod | CustomMethodId;
   mostCommonMethod?: AuthMethod | CustomMethodId;
   visibleMethods?: Array<AuthMethod | CustomMethodId>;
+  extendedDefaultOptions?: Partial<Record<AuthMethod, DefaultAuthMethod>>;
   customMethods?: CustomMethod[];
   onAuthMethodSelect: (authType: AuthMethod | CustomMethodId) => void;
   basicAuth?: Omit<BasicAuthProps, 'readOnly'>;
@@ -45,6 +46,7 @@ export const AuthMethodSettings: React.FC<Props> = ({
   selectedMethod,
   mostCommonMethod,
   visibleMethods: visibleMethodsFromProps,
+  extendedDefaultOptions,
   customMethods,
   onAuthMethodSelect,
   basicAuth,
@@ -75,9 +77,22 @@ export const AuthMethodSettings: React.FC<Props> = ({
         return acc;
       }, {}) ?? {};
 
+    const preparedDefaultOptions = {} as Record<AuthMethod, SelectableValue<AuthMethod>>;
+    let k: keyof typeof AuthMethod;
+    for (k in defaultOptions) {
+      if (extendedDefaultOptions && extendedDefaultOptions[k]) {
+        preparedDefaultOptions[k] = {
+          ...defaultOptions[k],
+          ...extendedDefaultOptions[k],
+        }
+      } else {
+        preparedDefaultOptions[k] = defaultOptions[k];
+      }
+    }
+
     const allOptions: Record<AuthMethod | CustomMethodId, SelectableValue<AuthMethod | CustomMethodId>> = {
       ...customOptions,
-      ...defaultOptions,
+      ...preparedDefaultOptions,
     };
 
     return visibleMethods
@@ -92,7 +107,7 @@ export const AuthMethodSettings: React.FC<Props> = ({
         }
         return option;
       });
-  }, [visibleMethods, customMethods, mostCommonMethod, hasSelect]);
+  }, [visibleMethods, customMethods, extendedDefaultOptions, mostCommonMethod, hasSelect]);
 
   let selected = selectedMethod;
   if (!hasSelect) {

--- a/src/ConfigEditor/Auth/types.ts
+++ b/src/ConfigEditor/Auth/types.ts
@@ -7,6 +7,11 @@ export enum AuthMethod {
   CrossSiteCredentials = 'CrossSiteCredentials',
 }
 
+export interface DefaultAuthMethod {
+  label?: string;
+  description?: string;
+};
+
 export type CustomMethodId = `custom-${string}`;
 
 export type CustomMethod = {

--- a/src/ConfigEditor/DataSourceDescription.test.tsx
+++ b/src/ConfigEditor/DataSourceDescription.test.tsx
@@ -31,7 +31,7 @@ describe('<DataSourceDescription />', () => {
       />
     );
 
-    expect(getByText('Fields marked in', { exact: false })).toBeInTheDocument();
+    expect(getByText('Fields marked with', { exact: false })).toBeInTheDocument();
   });
 
   it('should not render text about required fields when `hasRequiredFields` props is `false`', () => {
@@ -43,7 +43,7 @@ describe('<DataSourceDescription />', () => {
       />
     );
 
-    expect(() => getByText('Fields marked in', { exact: false })).toThrow();
+    expect(() => getByText('Fields marked with', { exact: false })).toThrow();
   });
 
   it('should render passed `className`', () => {

--- a/src/ConfigEditor/DataSourceDescription.tsx
+++ b/src/ConfigEditor/DataSourceDescription.tsx
@@ -46,7 +46,7 @@ export const DataSourceDescription = ({ dataSourceName, docsLink, hasRequiredFie
       </p>
       {hasRequiredFields && (
         <p className={styles.text}>
-          <i>Fields marked in * are required</i>
+          <i>Fields marked with * are required</i>
         </p>
       )}
     </div>


### PR DESCRIPTION
With this change we can use the provided authentication methods BUT with a twist - now it's possible to change the displayed name and description.

<img width="703" alt="Screenshot 2023-07-21 at 10 48 28" src="https://github.com/grafana/grafana-experimental/assets/112862936/c4db3f1d-c876-4b6a-8089-5181b0cab237">
