### PR TITLE
LLM: use new health check details in 'enabled' functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@types/uuid": "^8.3.3",
+    "semver": "^7.5.4",
     "uuid": "^8.3.2"
   }
 }

--- a/src/llms/constants.ts
+++ b/src/llms/constants.ts
@@ -1,2 +1,19 @@
+import { logWarning } from "@grafana/runtime";
+
+import { SemVer } from "semver";
+
 export const LLM_PLUGIN_ID = 'grafana-llm-app';
 export const LLM_PLUGIN_ROUTE = `/api/plugins/${LLM_PLUGIN_ID}`;
+
+// The LLM app was at version 0.2.0 before we added the health check.
+// If the health check fails, or the details don't exist on the response,
+// we should assume it's this older version.
+export let LLM_PLUGIN_VERSION = new SemVer('0.2.0');
+
+export function setLLMPluginVersion(version: string) {
+  try {
+    LLM_PLUGIN_VERSION = new SemVer(version);
+  } catch (e) {
+    logWarning('Failed to parse version of grafana-llm-app; assuming old version is present.')
+  }
+}

--- a/src/llms/openai.ts
+++ b/src/llms/openai.ts
@@ -14,7 +14,7 @@ import { getBackendSrv, getGrafanaLiveSrv, logDebug } from "@grafana/runtime";
 import { pipe, Observable, UnaryFunction } from "rxjs";
 import { filter, map, scan, takeWhile } from "rxjs/operators";
 
-import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE } from "./constants";
+import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE, setLLMPluginVersion } from "./constants";
 import { LLMAppHealthCheck } from "./types";
 
 const OPENAI_CHAT_COMPLETIONS_PATH = 'openai/v1/chat/completions';
@@ -344,7 +344,12 @@ export const enabled = async () => {
     }
     return false;
   }
-  // If the plugin is installed then check if it is configured.
+
   const { details } = response;
+  // Update the version if it's present on the response.
+  if (details.version !== undefined) {
+    setLLMPluginVersion(details.version);
+  }
+  // If the plugin is installed then check if it is configured.
   return details?.openAIEnabled ?? false;
 }

--- a/src/llms/openai.ts
+++ b/src/llms/openai.ts
@@ -15,6 +15,7 @@ import { pipe, Observable, UnaryFunction } from "rxjs";
 import { filter, map, scan, takeWhile } from "rxjs/operators";
 
 import { LLM_PLUGIN_ID, LLM_PLUGIN_ROUTE } from "./constants";
+import { LLMAppHealthCheck } from "./types";
 
 const OPENAI_CHAT_COMPLETIONS_PATH = 'openai/v1/chat/completions';
 
@@ -329,11 +330,12 @@ let loggedWarning = false;
 
 /** Check if the OpenAI API is enabled via the LLM plugin. */
 export const enabled = async () => {
+  // Run a health check to see if the plugin is installed.
+  let response: LLMAppHealthCheck;
   try {
-    const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
+    response = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/health`, undefined, undefined, {
       showSuccessAlert: false, showErrorAlert: false,
     });
-    return settings.enabled && (settings?.secureJsonFields?.openAIKey ?? false);
   } catch (e) {
     if (!loggedWarning) {
       logDebug(String(e));
@@ -342,4 +344,7 @@ export const enabled = async () => {
     }
     return false;
   }
+  // If the plugin is installed then check if it is configured.
+  const { details } = response;
+  return details?.openAIEnabled ?? false;
 }

--- a/src/llms/types.ts
+++ b/src/llms/types.ts
@@ -1,0 +1,6 @@
+export type LLMAppHealthCheck = {
+  details: {
+    openAIEnabled?: boolean;
+    vectorEnabled?: boolean;
+  };
+};

--- a/src/llms/types.ts
+++ b/src/llms/types.ts
@@ -2,5 +2,6 @@ export type LLMAppHealthCheck = {
   details: {
     openAIEnabled?: boolean;
     vectorEnabled?: boolean;
+    version?: string;
   };
 };

--- a/src/llms/vector.ts
+++ b/src/llms/vector.ts
@@ -9,7 +9,7 @@
  */
 
 import { getBackendSrv, logDebug } from "@grafana/runtime";
-import { LLM_PLUGIN_ROUTE } from "./constants";
+import { LLM_PLUGIN_ROUTE, setLLMPluginVersion } from "./constants";
 import { LLMAppHealthCheck } from "./types";
 
 interface SearchResultPayload extends Record<string, any> { }
@@ -89,7 +89,11 @@ export const enabled = async () => {
     }
     return false;
   }
-  // If the plugin is installed then check if it is configured.
   const { details } = response;
+  // Update the version if it's present on the response.
+  if (details.version !== undefined) {
+    setLLMPluginVersion(details.version);
+  }
+  // If the plugin is installed then check if it is configured.
   return details.vectorEnabled ?? false;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6551,7 +6551,7 @@ semver@^7.3.5, semver@^7.3.7, semver@^7.5.0:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.1:
+semver@^7.5.1, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==


### PR DESCRIPTION
The health check will be added in version 0.3.0 of the LLM app plugin.

It makes sense to keep the 'enabled' logic in the plugin since we'll have multiple clients in different languages and we don't want them to all have similar logic. Keeping track of the version will be very useful to enable backwards compatibility in this package.

See https://github.com/grafana/grafana-llm-app/pull/58 and https://github.com/grafana/grafana-llm-app/pull/62 for the health check PRs, and https://github.com/grafana/grafana-experimental/pull/82 for an example of why knowing the
version will be useful.