### PR TITLE
Bump to version 1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.7.3
+
+- Add UUID to streaming OpenAI requests
+- Add health check in enabled functions
 ## v1.7.2
 
 - Fix API return code matching in vector search support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR bumps the version to 1.7.3 and updates the changelog accordingly.