### PR TITLE
LLM: use new, more detailed health check results

### DIFF
--- a/src/llms/types.ts
+++ b/src/llms/types.ts
@@ -1,7 +1,42 @@
-export type LLMAppHealthCheck = {
-  details: {
-    openAI?: boolean;
-    vector?: boolean;
-    version?: string;
-  };
-};
+export interface HealthCheckResponse {
+  status: 'ok' | 'error';
+  details?: HealthCheckDetails;
+}
+
+export interface HealthCheckDetails {
+  openAI: OpenAIHealthDetails | boolean;
+  vector: VectorHealthDetails | boolean;
+  version: string;
+}
+
+export interface OpenAIHealthDetails {
+  // Whether the minimum required OpenAI settings have been provided.
+  configured: boolean;
+  // Whether we can call the OpenAI API with the provided settings.
+  ok: boolean;
+  // If set, the error returned when trying to call the OpenAI API.
+  // Will be undefined if ok is true.
+  error?: string;
+  // A map of model names to their health details.
+  // The health check attempts to call the OpenAI API with each
+  // of a few models and records the result of each call here.
+  models?: Record<string, OpenAIModelHealthDetails>;
+}
+
+export interface OpenAIModelHealthDetails {
+  // Whether we can use this model in calls to OpenAI.
+  ok: boolean;
+  // If set, the error returned when trying to call the OpenAI API.
+  // Will be undefined if ok is true.
+  error?: string;
+}
+
+export interface VectorHealthDetails {
+  // Whether the vector service has been enabled.
+  enabled: boolean;
+  // Whether we can use the vector service with the provided settings.
+  ok: boolean;
+  // If set, the error returned when trying to call the vector service.
+  // Will be undefined if ok is true.
+  error?: string;
+}

--- a/src/llms/vector.ts
+++ b/src/llms/vector.ts
@@ -10,7 +10,7 @@
 
 import { getBackendSrv, logDebug } from "@grafana/runtime";
 import { LLM_PLUGIN_ROUTE, setLLMPluginVersion } from "./constants";
-import { LLMAppHealthCheck } from "./types";
+import { HealthCheckResponse, VectorHealthDetails } from "./types";
 
 interface SearchResultPayload extends Record<string, any> { }
 
@@ -74,26 +74,48 @@ export async function search<T extends SearchResultPayload>(request: SearchReque
 let loggedWarning = false;
 
 /** Check if the vector API is enabled and configured via the LLM plugin. */
-export const enabled = async () => {
-  // Run a health check to see if the plugin is installed.
-  let response: LLMAppHealthCheck;
+export const enabled = async (): Promise<VectorHealthDetails> => {
+  // First check if the plugin is enabled.
+  try {
+    const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
+      showSuccessAlert: false, showErrorAlert: false,
+    });
+    if (!settings.enabled) {
+      return { enabled: false, ok: false, error: 'The Grafana LLM plugin is not enabled.' }
+    }
+  } catch (e) {
+    logDebug(String(e));
+    logDebug('Failed to check if the vector service is enabled. This is expected if the Grafana LLM plugin is not installed, and the above error can be ignored.');
+    loggedWarning = true;
+    return { enabled: false, ok: false, error: 'The Grafana LLM plugin is not installed.' }
+  }
+
+  // Run a health check to see if the vector service is configured on the plugin.
+  let response: HealthCheckResponse;
   try {
     response = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/health`, undefined, undefined, {
       showSuccessAlert: false, showErrorAlert: false,
     });
   } catch (e) {
+    // We shouldn't really get here if we managed to get the plugin's settings above,
+    // but catch this just in case.
     if (!loggedWarning) {
       logDebug(String(e));
       logDebug('Failed to check if vector service is enabled. This is expected if the Grafana LLM plugin is not installed, and the above error can be ignored.');
       loggedWarning = true;
     }
-    return false;
+    return { enabled: false, ok: false, error: 'The Grafana LLM plugin is not installed.' }
   }
+
   const { details } = response;
   // Update the version if it's present on the response.
-  if (details.version !== undefined) {
+  if (details?.version !== undefined) {
     setLLMPluginVersion(details.version);
   }
-  // If the plugin is installed then check if it is configured.
-  return details.vector ?? false;
+  if (details?.vector === undefined) {
+    return { enabled: false, ok: false, error: 'The Grafana LLM plugin is outdated; please update it.' }
+  }
+  return typeof details.vector === 'boolean' ?
+    { enabled: details.vector, ok: details.vector } :
+    details.vector;
 };


### PR DESCRIPTION
These details provide more context to the caller so they can display better errors to the user. We return full details from `enabled` functions but in some cases (where the app plugin is older) we may have to infer some of these fields because we have limited information.