### PR TITLE
llms: separate health and enabled methods

### DIFF
--- a/src/llms/openai.test.ts
+++ b/src/llms/openai.test.ts
@@ -1,0 +1,37 @@
+import { enabled } from './openai';
+import { LLM_PLUGIN_ROUTE } from './constants';
+import { getBackendSrv } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+}));
+
+describe('enabled', () => {
+  it('should return false if not configured', async () => {
+    (getBackendSrv as jest.Mock).mockImplementation(() => ({
+      get: jest.fn().mockReturnValue(Promise.resolve({ enabled: false })),
+    }));
+
+    // Call the enabled function
+    const result = await enabled();
+    expect(result).toBe(false);
+  });
+
+  it('should return true if configured', async () => {
+    (getBackendSrv as jest.Mock).mockImplementation(() => ({
+      get: jest.fn().mockImplementation((url: string) => {
+        if (url === `${LLM_PLUGIN_ROUTE}/settings`) {
+          return Promise.resolve({ enabled: true });
+        } else if (url === `${LLM_PLUGIN_ROUTE}/health`) {
+          return Promise.resolve({ details: { openAI: { configured: true, ok: true } } });
+        }
+        // raise an error if we get here
+        throw new Error('unexpected url');
+      }),
+    }));
+
+    // Call the enabled function
+    const result = await enabled();
+    expect(result).toBe(true);
+  });
+});

--- a/src/llms/openai.ts
+++ b/src/llms/openai.ts
@@ -487,10 +487,7 @@ export function useOpenAIStream(
     [notifyError]
   );
 
-  const { error: enabledError, value: isEnabled } = useAsync(
-    async () => await enabled().then((response) => response.ok),
-    [enabled]
-  );
+  const { error: enabledError, value: isEnabled } = useAsync(async () => await enabled(), [enabled]);
 
   const { error: asyncError, value } = useAsync(async () => {
     if (!isEnabled || !messages.length) {

--- a/src/llms/openai.ts
+++ b/src/llms/openai.ts
@@ -347,7 +347,7 @@ export function streamChatCompletions(request: ChatCompletionsRequest): Observab
 let loggedWarning = false;
 
 /** Check if the OpenAI API is enabled via the LLM plugin. */
-export const enabled = async (): Promise<OpenAIHealthDetails> => {
+export const health = async (): Promise<OpenAIHealthDetails> => {
   // First check if the plugin is enabled.
   try {
     const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
@@ -389,6 +389,11 @@ export const enabled = async (): Promise<OpenAIHealthDetails> => {
   return typeof details.openAI === 'boolean' ?
     { configured: details.openAI, ok: details.openAI } :
     details.openAI;
+}
+
+export const enabled = async (): Promise<boolean> => {
+  const healthDetails = await health();
+  return healthDetails.configured && healthDetails.ok;
 }
 
 /**

--- a/src/llms/vector.test.ts
+++ b/src/llms/vector.test.ts
@@ -1,0 +1,37 @@
+import { enabled } from './vector';
+import { LLM_PLUGIN_ROUTE } from './constants';
+import { getBackendSrv } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn(),
+}));
+
+describe('enabled', () => {
+  it('should return false if not configured', async () => {
+    (getBackendSrv as jest.Mock).mockImplementation(() => ({
+      get: jest.fn().mockReturnValue(Promise.resolve({ enabled: false })),
+    }));
+
+    // Call the enabled function
+    const result = await enabled();
+    expect(result).toBe(false);
+  });
+
+  it('should return true if configured', async () => {
+    (getBackendSrv as jest.Mock).mockImplementation(() => ({
+      get: jest.fn().mockImplementation((url: string) => {
+        if (url === `${LLM_PLUGIN_ROUTE}/settings`) {
+          return Promise.resolve({ enabled: true });
+        } else if (url === `${LLM_PLUGIN_ROUTE}/health`) {
+          return Promise.resolve({ details: { vector: { enabled: true, ok: true } } });
+        }
+        // raise an error if we get here
+        throw new Error('unexpected url');
+      }),
+    }));
+
+    // Call the enabled function
+    const result = await enabled();
+    expect(result).toBe(true);
+  });
+});

--- a/src/llms/vector.ts
+++ b/src/llms/vector.ts
@@ -78,7 +78,7 @@ export async function search<T extends SearchResultPayload>(request: SearchReque
 let loggedWarning = false;
 
 /** Check if the vector API is enabled and configured via the LLM plugin. */
-export const enabled = async (): Promise<VectorHealthDetails> => {
+export const health = async (): Promise<VectorHealthDetails> => {
   // First check if the plugin is enabled.
   try {
     const settings = await getBackendSrv().get(`${LLM_PLUGIN_ROUTE}/settings`, undefined, undefined, {
@@ -123,3 +123,8 @@ export const enabled = async (): Promise<VectorHealthDetails> => {
     { enabled: details.vector, ok: details.vector } :
     details.vector;
 };
+
+export const enabled = async (): Promise<boolean> => {
+  const healthDetails = await health();
+  return healthDetails.enabled && healthDetails.ok;
+}


### PR DESCRIPTION
Resolves https://github.com/grafana/grafana-experimental/issues/95
Revert `enabled()` back to the contract we had in 1.7.0-1.7.3 where it returns a boolean.
This way all our current features built on it (and the examples in https://github.com/grafana/grafana-llmexamples-app) will have a proper enabled check again.

Example health check details
```json
{
    "openAI": {
        "configured": true,
        "models": {
            "gpt-3.5-turbo": {
                "ok": true
            },
            "gpt-4": {
                "ok": true
            }
        },
        "ok": true
    },
    "vector": {
        "enabled": true,
        "error": "vector service health check failed: get health: <error>",
        "ok": false
    },
    "version": "0.4.0"
}
```