### PR TITLE
bump to 1.7.5 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.7.5
+
+- Add new ConfigDescriptionLink component
+
+
 ## v1.7.4
 
 - Add support for filtered vector search

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/ConfigEditor/ConfigSection/ConfigDescriptionLink.test.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigDescriptionLink.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { ConfigDescriptionLink } from './ConfigDescriptionLink';
+
+describe('<ConfigDescriptionLink />', () => {
+  const props = {
+    description: 'Test description',
+    suffix: 'testSuffix',
+    feature: 'Test feature',
+  };
+  it('should render description', () => {
+    render( <ConfigDescriptionLink {...props} />);
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+  });
+
+  it('should render feature text', () => {
+    render( <ConfigDescriptionLink {...props} />);
+    expect(screen.getByText('Learn more about Test feature')).toBeInTheDocument();
+  });
+
+  it('should create correct link using suffix', () => {
+    render( <ConfigDescriptionLink {...props} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://grafana.com/docs/grafana/next/datasources/testSuffix');
+  });
+});
+

--- a/src/ConfigEditor/ConfigSection/ConfigDescriptionLink.tsx
+++ b/src/ConfigEditor/ConfigSection/ConfigDescriptionLink.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+type Props = {
+  description: string;
+  suffix: string;
+  feature: string;
+};
+
+export function ConfigDescriptionLink(props: Props) {
+  const { description, suffix, feature } = props;
+  const text = `Learn more about ${feature}`;
+  const styles = useStyles2(getStyles);
+
+  return (
+    <span className={styles.container}>
+      {description}
+      <a
+        aria-label={text}
+        href={`https://grafana.com/docs/grafana/next/datasources/${suffix}`}
+        rel="noreferrer"
+        target="_blank"
+      >
+        {text}
+      </a>
+    </span>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      color: theme.colors.text.secondary,
+      a: css({
+        color: theme.colors.text.link,
+        textDecoration: 'underline',
+        marginLeft: '5px',
+        '&:hover': {
+          textDecoration: 'none',
+        },
+      }),
+    }),
+  };
+};

--- a/src/ConfigEditor/ConfigSection/index.ts
+++ b/src/ConfigEditor/ConfigSection/index.ts
@@ -1,2 +1,3 @@
 export { ConfigSection } from './ConfigSection';
 export { ConfigSubSection } from './ConfigSubSection';
+export { ConfigDescriptionLink } from './ConfigDescriptionLink';

--- a/src/ConfigEditor/index.ts
+++ b/src/ConfigEditor/index.ts
@@ -1,5 +1,5 @@
 export { DataSourceDescription } from './DataSourceDescription';
-export { ConfigSection, ConfigSubSection } from './ConfigSection';
+export { ConfigSection, ConfigSubSection, ConfigDescriptionLink } from './ConfigSection';
 export { Auth, AuthMethod, convertLegacyAuthProps } from './Auth';
 export type { AuthProps } from './Auth';
 export { ConnectionSettings } from './Connection';


### PR DESCRIPTION
This PR bumps `@grafana/experimental` to 1.7.5 and adds the `ConfigDescriptionLink` component + adds test. Currently this component is in `grafana/grafana` repo in `public/app/core/components`, but it is in 100% of cases used as description together with `ConfigSubSection` that is in this repository. 