### PR TITLE
added partial codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/src/sql-editor @grafana/oss-big-tent


### PR DESCRIPTION
the oss-big-tent squad is fine with owning the sql-related code in this repo, so i made a CODEOWNERS that reflects this. of course, if someone else wants to own it too, feel free to comment and we can modify this👍 .


(NOTE: github is complaining that the codeowners is not valid because oss-big-tent has no write access, i'll solve that if/when this gets approved)