### PR TITLE
Codeowners: Add owners for Visual query builder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /src/sql-editor @grafana/oss-big-tent
+/src/VisualQueryBuilder @grafana/observability-logs @grafana/observability-metrics


### PR DESCRIPTION
I've added obs-logs and obs-metrics as owners of visual query builder code in this repo.

(NOTE: github is complaining that the codeowners is not valid because @grafana/observability-logs and @grafana/observability-metrics has no write access, i'll solve that if/when this gets approved)