### PR TITLE
bump to 1.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR bump `@grafana/experimental` package to 1.7.6 to release components of **Visual query builder** so it can be used in `grafana/grafana` for data sources.