### PR TITLE
bump to 1.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/VisualQueryBuilder/index.ts
+++ b/src/VisualQueryBuilder/index.ts
@@ -10,4 +10,4 @@ export { QueryHeaderSwitch } from './components/QueryHeaderSwitch';
 export { QueryOptionGroup } from './components/QueryOptionGroup';
 export { RawQuery } from './components/RawQuery';
 export type { QueryBuilderOperationParamEditorProps, QueryBuilderLabelFilter, QueryBuilderOperation, QueryBuilderOperationParamValue, QueryBuilderOperationDefinition, QueryBuilderOperationParamDef, VisualQueryModeller, VisualQueryBinary, VisualQuery, QueryStats } from './types';
-export { QueryEditorMode } from './types';
+export { QueryEditorMode, BINARY_OPERATIONS_KEY } from './types';


### PR DESCRIPTION
This PR bumps `@grafana/experimental` package to 1.7.7 to release changes done to Visual query builder so it can be used in grafana/grafana for data sources.