### PR TITLE
LabelFilters: Fix bug with running incomplete query

### DIFF
--- a/src/VisualQueryBuilder/components/LabelFilterItem.tsx
+++ b/src/VisualQueryBuilder/components/LabelFilterItem.tsx
@@ -14,7 +14,7 @@ interface Props {
   defaultOp: string;
   item: Partial<QueryBuilderLabelFilter>;
   items: Array<Partial<QueryBuilderLabelFilter>>;
-  onChange: (value: QueryBuilderLabelFilter) => void;
+  onChange: (value: Partial<QueryBuilderLabelFilter>) => void;
   onGetLabelNames: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<Array<SelectableValue<string>>>;
   onGetLabelValues: (forLabel: Partial<QueryBuilderLabelFilter>) => Promise<Array<SelectableValue<string>>>;
   onDelete: () => void;
@@ -98,7 +98,6 @@ export function LabelFilterItem({
               if (change.value) {
                 onChange({
                   ...item,
-                  value: item.value ?? '',
                   op: item.op ?? defaultOp,
                   label: change.value,
                 });
@@ -116,9 +115,8 @@ export function LabelFilterItem({
               if (change.value) {
                 onChange({
                   ...item,
-                  label: item.label ?? '',
                   op: change.value,
-                  value: isMultiSelect(change.value) ? (item.value ?? '') : getSelectOptionsFromString(item?.value)[0],
+                  value: isMultiSelect(change.value) ? item.value  : getSelectOptionsFromString(item?.value)[0],
                 });
               }
             }}
@@ -159,7 +157,6 @@ export function LabelFilterItem({
                   ...item,
                   value: change.value,
                   op: item.op ?? defaultOp,
-                  label: item.label ?? '',
                 });
               } else {
                 // otherwise, we're dealing with a multi-value select which is array of options

--- a/src/VisualQueryBuilder/components/LabelFilters.test.tsx
+++ b/src/VisualQueryBuilder/components/LabelFilters.test.tsx
@@ -89,6 +89,23 @@ describe('LabelFilters', () => {
     setup({ labelsFilters: [], labelFilterRequired: true });
     expect(screen.getByText(MISSING_LABEL_FILTER_ERROR_MESSAGE)).toBeInTheDocument();
   });
+  
+  it('runs onChange after all selects are changed', async () => {
+    const { onChange } = setup({ labelsFilters: [{ label: 'foo', op: '=', value: 'bar' }] });
+    await userEvent.click(getAddButton());
+    expect(screen.getAllByText('Select label')).toHaveLength(1);
+    expect(screen.getAllByText('Select value')).toHaveLength(1);
+    const { name, value, op } = getLabelSelects(1);
+    await selectOptionInTest(name, 'baz');
+    expect(onChange).not.toBeCalled();
+    await selectOptionInTest(op, '!=');
+    expect(onChange).not.toBeCalled();
+    await selectOptionInTest(value, 'qux');
+    expect(onChange).toBeCalledWith([
+      { label: "foo", op: "=", value: "bar" }, 
+      { label: "baz", op: "!=", value: "qux" }
+    ]);    
+  });
 });
 
 function setup(propOverrides?: Partial<ComponentProps<typeof LabelFilters>>) {
@@ -122,6 +139,7 @@ function getLabelSelects(index = 0) {
   const selects = getAllByRole(labels.parentElement!.parentElement!.parentElement!, 'combobox');
   return {
     name: selects[3 * index],
+    op: selects[3 * index + 1],
     value: selects[3 * index + 2],
   };
 }


### PR DESCRIPTION
In `LabelFilterItem` we incorrectly assumed that the type of `onChange` is `onChange: (value: Partial<QueryBuilderLabelFilter>) => void`; and to fix types assertion, I defaulted to empty string. Which is incorrect and was causing updating of query after each part of label filter changed. But we want to update query only after all parts of label filter are updated. 

Also correct type for `OnChange` in `LabelFilterItem` should be with `Partial`
<img width="920" alt="image" src="https://github.com/grafana/grafana-experimental/assets/30407135/2a425689-5ba4-4067-b39c-36b497b47a41">
