### PR TITLE
bump to 1.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.7.8
+
+- Fix bug in `LabelFilters` component that caused creating incorrect query
+
+## v1.7.7
+
+- Remove a need to pass `innerQueryPlaceholder` prop to `OperationHeader`, `OperationList` and `OperationListExplained` and instead specify it in QueryModeller
+
+## v1.7.6
+
+- Release Visual query builder components
+
 ## v1.7.5
 
 - Add new ConfigDescriptionLink component
-
 
 ## v1.7.4
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR bumps @grafana/experimental package to 1.7.8 to release bug fix for `LabelFilters` component. I have also updated Changelog as I have forgotten to change it during 1.7.6 and 1.7.7 releases.