### PR TITLE
bump to 1.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.7.9
+
+- Fix bug in `OperationEditor` component causing re-mounting issue 
+- Update e2e selectors in `LabelFilters` to ensure easy testing
+
 ## v1.7.8
 
 - Fix bug in `LabelFilters` component that caused creating incorrect query

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/experimental",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "Experimental Grafana components and APIs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
This PR bumps @grafana/experimental package to 1.7.9 and adds changes to Changelog. 