### PR TITLE
Update README with ongoing deprecation plans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Grafana Experimental
 
+> [!WARNING]
+> As part of our ongoing efforts to improve and streamline our UI components, we are gradually deprecating this repository.\
+> Components previously housed here are being migrated to other UI components packages such as [grafana/ui](https://github.com/grafana/grafana/tree/main/packages/grafana-ui) and [grafana/plugin-ui](https://github.com/grafana/plugin-ui).\
+> Please note that future development and improvements should happen in the respective new locations. We recommend developers to start using and referencing the new packages in their projects.\
+> Thank you for your understanding and cooperation during this transition.
+
 The main difference between grafana/experimental and grafana/ui is how the components are versioned. Having a separate "experimental" package allows us to release breaking changes when necessary while the grafana/ui package follows a slower-moving policy.
 
 As developers use and test the components and report issues, the maintainers learn more about shortcomings of the components. The older and more used a component is, the less likely it is that new issues will be found and subsequently need to introduce breaking changes.


### PR DESCRIPTION
This PR updates the readme with our plans to deprecate this repository.
You can view [this doc](https://docs.google.com/document/d/13b5_d5unZeDfNXmo6BfhORM_pOdb-NXyv2H-hJAABV0/) for more info.

**Linked to**: https://github.com/grafana/grafana-experimental/issues/117

**How the formatting looks**:
<img width="2255" alt="Screenshot 2024-02-26 at 11 17 32" src="https://github.com/grafana/grafana-experimental/assets/34524710/60e9c249-8497-4695-a05f-fd11f3ff83a3">
