### PR TITLE
fix: Auth: clear TLS related data when TLS setting is toggled off

### DIFF
--- a/src/ConfigEditor/Auth/utils.test.ts
+++ b/src/ConfigEditor/Auth/utils.test.ts
@@ -315,7 +315,7 @@ describe('utils', () => {
       });
     });
 
-    it('should call `selfSignedCertificate.onToggle` correctly', () => {
+    it('should call `selfSignedCertificate.onToggle` correctly when toggled on', () => {
       const tls = getTLSProps(config, onChange);
 
       tls?.selfSignedCertificate.onToggle(true);
@@ -327,6 +327,26 @@ describe('utils', () => {
           ...config.jsonData,
           tlsAuthWithCACert: true,
         },
+      });
+    });
+
+    it('should call `selfSignedCertificate.onToggle` correctly when toggled off', () => {
+      const testConfig: Config = {
+        ...config,
+        jsonData: { ...config.jsonData, tlsAuthWithCACert: true },
+        secureJsonData: { ...config.secureJsonData, tlsCACert: 'cert' },
+        secureJsonFields: { ...config.secureJsonFields, tlsCACert: true },
+      };
+      const tls = getTLSProps(testConfig, onChange);
+
+      tls?.selfSignedCertificate.onToggle(false);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        ...testConfig,
+        jsonData: { ...testConfig.jsonData, tlsAuthWithCACert: false },
+        secureJsonData: { ...testConfig.secureJsonData, tlsCACert: '' },
+        secureJsonFields: { ...testConfig.secureJsonFields, tlsCACert: false },
       });
     });
 
@@ -358,7 +378,7 @@ describe('utils', () => {
       });
     });
 
-    it('should call `TLSClientAuth.onToggle` correctly', () => {
+    it('should call `TLSClientAuth.onToggle` correctly when toggled on', () => {
       const tls = getTLSProps(config, onChange);
 
       tls?.TLSClientAuth.onToggle(true);
@@ -367,6 +387,26 @@ describe('utils', () => {
       expect(onChange).toHaveBeenCalledWith({
         ...config,
         jsonData: { ...config.jsonData, tlsAuth: true },
+      });
+    });
+
+    it('should call `TLSClientAuth.onToggle` correctly when toggled off', () => {
+      const testConfig: Config = {
+        ...config,
+        jsonData: { ...config.jsonData, tlsAuth: true, serverName: 'test.server.name' },
+        secureJsonData: { ...config.secureJsonData, tlsClientCert: 'cert', tlsClientKey: 'key' },
+        secureJsonFields: { ...config.secureJsonFields, tlsClientCert: true, tlsClientKey: true },
+      };
+      const tls = getTLSProps(testConfig, onChange);
+
+      tls?.TLSClientAuth.onToggle(false);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith({
+        ...testConfig,
+        jsonData: { ...testConfig.jsonData, tlsAuth: false, serverName: '' },
+        secureJsonData: { ...testConfig.secureJsonData, tlsClientCert: '', tlsClientKey: '' },
+        secureJsonFields: { ...testConfig.secureJsonFields, tlsClientCert: false, tlsClientKey: false },
       });
     });
 

--- a/src/ConfigEditor/Auth/utils.ts
+++ b/src/ConfigEditor/Auth/utils.ts
@@ -88,10 +88,17 @@ export function getTLSProps<C extends Config = Config>(config: C, onChange: OnCh
       enabled: Boolean(config.jsonData.tlsAuthWithCACert),
       certificateConfigured: config.secureJsonFields.tlsCACert,
       onToggle: (enabled) =>
-        onChange({
-          ...config,
-          jsonData: { ...config.jsonData, tlsAuthWithCACert: enabled },
-        }),
+        enabled
+          ? onChange({
+              ...config,
+              jsonData: { ...config.jsonData, tlsAuthWithCACert: enabled },
+            })
+          : onChange({
+              ...config,
+              jsonData: { ...config.jsonData, tlsAuthWithCACert: enabled },
+              secureJsonData: { ...config.secureJsonData, tlsCACert: '' },
+              secureJsonFields: { ...config.secureJsonFields, tlsCACert: false },
+            }),
       onCertificateChange: (certificate) =>
         onChange({
           ...config,
@@ -110,10 +117,17 @@ export function getTLSProps<C extends Config = Config>(config: C, onChange: OnCh
       clientCertificateConfigured: config.secureJsonFields.tlsClientCert,
       clientKeyConfigured: config.secureJsonFields.tlsClientKey,
       onToggle: (enabled) =>
-        onChange({
-          ...config,
-          jsonData: { ...config.jsonData, tlsAuth: enabled },
-        }),
+        enabled
+          ? onChange({
+              ...config,
+              jsonData: { ...config.jsonData, tlsAuth: enabled },
+            })
+          : onChange({
+              ...config,
+              jsonData: { ...config.jsonData, tlsAuth: enabled, serverName: '' },
+              secureJsonData: { ...config.secureJsonData, tlsClientCert: '', tlsClientKey: '' },
+              secureJsonFields: { ...config.secureJsonFields, tlsClientCert: false, tlsClientKey: false },
+            }),
       onServerNameChange: (serverName) =>
         onChange({
           ...config,


### PR DESCRIPTION
Clearing TLS related settings when TLS setting is toggled off in the UI.

Closes https://github.com/grafana/grafana-experimental/issues/120

Updating `@grafana/experimental` package version in grafana repo will be required to fully resolve the described issue with Loki.