### PR TITLE
don't use PropsWithChildren since we already specify a children type

### DIFF
--- a/src/sql-editor/components/SQLEditor.tsx
+++ b/src/sql-editor/components/SQLEditor.tsx
@@ -78,7 +78,7 @@ export const SQLEditor = ({
   language = { id: STANDARD_SQL_LANGUAGE },
   width,
   height,
-}: React.PropsWithChildren<SQLEditorProps>) => {
+}: SQLEditorProps) => {
   const monacoRef = useRef<monacoTypes.editor.IStandaloneCodeEditor | null>(null);
   const langUid = useRef<string>();
   // create unique language id for each SQLEditor instance


### PR DESCRIPTION
- [previous PR](https://github.com/grafana/grafana-experimental/pull/127) changed to use `PropsWithChildren`, but we already define the child type in the props
- this results in core not being able to upgrade to this version since it can never specify the child type correctly
- see https://github.com/grafana/grafana/pull/93919 for example PR and https://drone.grafana.net/grafana/grafana/199808 for an example failing drone build