### PR TITLE
Query builder: update title when operation is disbled

### DIFF
--- a/src/VisualQueryBuilder/components/OperationHeader.tsx
+++ b/src/VisualQueryBuilder/components/OperationHeader.tsx
@@ -66,7 +66,7 @@ export const OperationHeader = React.memo<Props>(
                   onClick={() => onToggle(index)}
                   fill="text"
                   variant="secondary"
-                  title="Disable operation"
+                  title={operation.disabled ? "Enable operation" : "Disable operation"}
                 />
               )}
               <Button


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana-experimental/pull/135 where I realized that we were not changing the title when the operation was disabled.